### PR TITLE
Allow default avatars display not only the Gravatar logo

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -3,7 +3,7 @@
 	<li <?php comment_class(); ?>>
 		<article id="comment-<?php comment_ID(); ?>">
 			<header class="comment-author vcard">
-				<?php echo get_avatar($comment,$size='32',$default='<path_to_url>' ); ?>
+				<?php echo get_avatar($comment,$size='32'); ?>
 				<?php printf(__('<cite class="fn">%s</cite>'), get_comment_author_link()) ?>
 				<time datetime="<?php echo comment_date('c') ?>"><a href="<?php echo htmlspecialchars( get_comment_link( $comment->comment_ID ) ) ?>"><?php printf(__('%1$s'), get_comment_date(),  get_comment_time()) ?></a></time>
 				<?php edit_comment_link(__('(Edit)'),'  ','') ?>


### PR DESCRIPTION
Hello,

I just found that default avatars in the comment sections always display the Gravatar logo, regardless of the setting in the admin page.

I suggest modifying comments.php so that the default avatars are displayed according to the setting in Admin > Settings > Discussion > Avatars > Default Avatar. :)

jsliang
