### PR TITLE
The original roots_get_home_patch() function fails on my local ubuntu env

### DIFF
--- a/includes/roots-htaccess.php
+++ b/includes/roots-htaccess.php
@@ -1,16 +1,7 @@
 <?php  
 
 function roots_get_home_path() {
-	$home = get_option( 'home' );
-	$siteurl = get_option( 'siteurl' );
-	if ( $home != '' && $home != $siteurl ) {
-	        $wp_path_rel_to_home = str_replace($home, '', $siteurl); /* $siteurl - $home */
-	        $pos = strpos($_SERVER["SCRIPT_FILENAME"], $wp_path_rel_to_home);
-	        $home_path = substr($_SERVER["SCRIPT_FILENAME"], 0, $pos);
-		$home_path = trailingslashit( $home_path );
-	} else {
-		$home_path = ABSPATH;
-	}
+        $home_path = trailingslashit($_SERVER['DOCUMENT_ROOT']);
 	return $home_path;
 }
 


### PR DESCRIPTION
The original roots_get_home_patch() function fails on my local ubuntu env.
Dunno why it ever worked but its not working anymore. 
With this fix it's working great and is far more simple. 
Any reason why you don't use this ?

Regards ;-)
