### PR TITLE
Fix Wpml conflict.

### DIFF
--- a/includes/roots-activation.php
+++ b/includes/roots-activation.php
@@ -53,14 +53,19 @@ if (is_admin() && 'themes.php' === $pagenow && isset( $_GET['activated'])) {
 	
 	// automatically create menus and set their locations
 	// add all pages to the Primary Navigation
-	$primary_nav_id = wp_create_nav_menu('Roots Primary Navigation', array('slug' => 'roots_primary_navigation'));
-	$utility_nav_id = wp_create_nav_menu('Roots Utility Navigation', array('slug' => 'roots_utility_navigation'));
-	set_theme_mod('nav_menu_locations', array(
-		'primary_navigation' => $primary_nav_id, 
-		'utility_navigation' => $utility_nav_id
-	));	
-	
-	$primary_nav = wp_get_nav_menu_object('Primary Navigation');
+   $args_nav_theme_mod = false;
+   if (!has_nav_menu(utility_navigation)){
+      $utility_nav_id = wp_create_nav_menu('Utility Navigation', array('slug' => 'utility_navigation'));
+      $args_nav_theme_mod['utility_navigation'] = $utility_nav_id;
+   }
+   if (!has_nav_menu(primary_navigation)){
+      $primary_nav_id = wp_create_nav_menu('Primary Navigation', array('slug' => 'primary_navigation'));
+      $args_nav_theme_mod['primary_navigation'] = $primary_nav_id;
+   }
+   if ($args_nav_theme_mod)
+      set_theme_mod('nav_menu_locations', $args_nav_theme_mod );
+
+  	$primary_nav = wp_get_nav_menu_object('Primary Navigation');
 	$primary_nav_term_id = (int) $primary_nav->term_id;	
 	$pages = get_pages();
 	foreach($pages as $page) {


### PR DESCRIPTION
Nav menu's name was too generic and generated a fatal exception when activating roots AFTER wpml's been activated. This should prevent future conflict with other plugins too.
