### PR TITLE
Escape slashes in roots_gallery_style

### DIFF
--- a/inc/roots-cleanup.php
+++ b/inc/roots-cleanup.php
@@ -176,7 +176,7 @@ function roots_remove_recent_comments_style() {
 
 // remove CSS from gallery
 function roots_gallery_style($css) {
-	return preg_replace("/<style type='text/css'>(.*?)</style>/s", '', $css);
+	return preg_replace("/<style type='text\/css'>(.*?)<\/style>/s", '', $css);
 }
 
 function roots_head_cleanup() {


### PR DESCRIPTION
In roots_gallery_style() (in roots-cleanup.php) slashes in the first argument to preg_replace -- 'text/css' and '</style>' -- need to be escaped.

This fixes an error I was having with the roots custom gallery.
