### PR TITLE
Added support for Sass and Compass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.sass-cache

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,1 @@
+rvm ruby-1.9.2@wordpress-roots

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source :rubygems
+
+gem 'rake'
+gem 'sass', '~> 3.1.5'
+gem 'compass', '~> 0.11.5'
+gem 'css_parser', '~> 1.1.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    chunky_png (1.2.0)
+    compass (0.11.5)
+      chunky_png (~> 1.2)
+      fssm (>= 0.2.7)
+      sass (~> 3.1)
+    css_parser (1.1.9)
+    fssm (0.2.7)
+    rake (0.9.2)
+    sass (3.1.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  compass (~> 0.11.5)
+  css_parser (~> 1.1.9)
+  rake
+  sass (~> 3.1.5)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,71 @@
+require "rubygems"
+require "bundler"
+Bundler.setup
+
+# Settings for Compass and rsync deployment
+css_dir               = "stylesheets/css"
+theme                 = "roots"
+ssh_user              = "username"
+remote_root           = "~/path/on/server"
+
+namespace :styles do
+  
+  desc "Run compass stats"
+  task :stats => ["stats:default"]
+
+  namespace :stats do
+
+    task :default do
+      puts "*** Running compass stats ***"
+      system "compass stats"
+    end
+
+    desc "Create a log of compass stats"
+    task :log do
+      t = DateTime.now
+      filename = "compass-stats-#{t.strftime("%Y%m%d")}-#{t.strftime("%H%M%S")}.log"
+      puts "*** Logging stats ***"
+      system "compass stats > log/#{filename}"
+      puts "Created log/#{filename}"
+    end
+    
+  end
+  
+  desc "Clear the styles"
+  task :clear => ["compile:clear"]
+  
+  desc "List the styles"
+  task :list do
+    system "ls -lh #{css_dir}"
+  end
+  
+  desc "Compile new styles"
+  task :compile => ["compile:default"]
+
+  namespace :compile do
+    
+    task :clear do
+      puts "*** Clearing styles ***"
+      system "rm -Rfv #{css_dir}/*"
+    end
+
+    task :default => :clear do
+      puts "*** Compiling styles ***"
+      system "compass compile"
+    end
+
+    desc "Compile new styles for production"
+    task :production => :clear do
+      puts "*** Compiling styles ***"
+      system "compass compile --output-style compressed --force"
+    end
+
+  end
+  
+end
+
+desc "Clears and generates new styles, builds and deploys"
+task :deploy do
+  puts "*** Deploying the site ***"
+  system "rsync -avz --delete . #{ssh_user}:#{remote_root}/wp-content/themes/#{theme}/"
+end

--- a/config.rb
+++ b/config.rb
@@ -1,0 +1,27 @@
+# Compass Configuration
+
+# HTTP paths
+# http_path             = '/'
+# http_stylesheets_path = '/stylesheets'
+# http_images_path      = '/img'
+# http_javascripts_path = '/js'
+
+# File system locations
+sass_dir              = 'stylesheets/sass'
+css_dir               = 'stylesheets/css'
+images_dir            = 'img'
+javascripts_dir       = 'js'
+
+# Set to true for easier debugging
+line_comments         = false
+preferred_syntax      = :scss
+
+# CSS output style - :nested, :expanded, :compact, or :compressed
+output_style          = :expanded
+
+# Determine whether Compass asset helper functions generate relative
+# or absolute paths
+relative_assets       = true
+
+# Learn more: http://compass-style.org/docs/tutorials/configuration-reference/
+

--- a/stylesheets/css/screen.css
+++ b/stylesheets/css/screen.css
@@ -1,0 +1,55 @@
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+}
+
+body {
+  line-height: 1;
+}
+
+ol, ul {
+  list-style: none;
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+caption, th, td {
+  text-align: left;
+  font-weight: normal;
+  vertical-align: middle;
+}
+
+q, blockquote {
+  quotes: none;
+}
+q:before, q:after, blockquote:before, blockquote:after {
+  content: "";
+  content: none;
+}
+
+a img {
+  border: none;
+}
+
+article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section, summary {
+  display: block;
+}

--- a/stylesheets/sass/screen.scss
+++ b/stylesheets/sass/screen.scss
@@ -1,0 +1,6 @@
+@import "compass";
+
+// Mixin the Compass global reset
+@include global-reset;
+
+// Your Sass goes here ...


### PR DESCRIPTION
Added support for Sass and Compass. Sass resides in stylesheets/sass and compiles to stylesheets/css. Includes Rake tasks, rsync deployment, an .rvmrc file setting the RVM ruby and the gemset as well as Bundler support for installing your gems.
