### PR TITLE
Theme Options Page: Show Default #main and #sidebar classes for currently selected framework

### DIFF
--- a/inc/roots-options.php
+++ b/inc/roots-options.php
@@ -174,7 +174,7 @@ function roots_theme_options_render_page() {
 			<?php
 				settings_fields('roots_options');
 				$roots_options = roots_get_theme_options();
-				$roots_default_options = roots_get_default_theme_options();
+				$roots_default_options = roots_get_default_theme_options($roots_options['css_framework']);
 			?>
 
 			<table class="form-table">


### PR DESCRIPTION
When the theme options page is loaded (or reloaded on form-submission), the form displays default classes for the blueprint framework regardless of what framework is currently selected.

I think the tradeoff in added complexity to roots_get_default_theme_options is worth it for the flexibility of accepting an argument and filtering the default argument -- especially for folks building child themes.
