### PR TITLE
Fixes "Trying to get property of non-object" error on 404 pages 

### DIFF
--- a/header.php
+++ b/header.php
@@ -25,11 +25,7 @@
 	<script defer src="<?php echo get_template_directory_uri(); ?>/js/script.js"></script>
 </head>
 
-<body <?php if (isset($post)) {
-		body_class($post->post_name);
-	} else {
-		body_class();
-	}?>>
+<body <?php if (isset($post)) { body_class($post->post_name); } else { body_class(); }?>>
 
 	<?php roots_wrap_before(); ?>
 	<div id="wrap" class="container" role="document">


### PR DESCRIPTION
`$post` is not set if you are on a 404 page, so we need to check if it is set before we call 
`$post->post_name`, etc. (note that you would have to have `WP_DEBUG` set to `true` in wp-config.php in order
to see this issue)
