### PR TITLE
add roots_detect_slug() for use with body_class()

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -129,4 +129,21 @@ function roots_author_link($link) {
 
 add_filter('the_author_posts_link', 'roots_author_link');
 
+function roots_detect_slug() {
+	$term = get_queried_object();
+	if( is_single() )
+		$cat = get_the_category();
+
+	if( ! empty( $cat ) )
+		return $cat[0]->slug;
+	elseif( isset( $term->slug ) )
+		return $term->slug;
+	elseif( isset( $term->page_name ) )
+		return $term->page_name;
+	elseif( isset( $term->post_name ) )
+		return $term->post_name;
+	else
+		return;
+}
+
 ?>

--- a/header.php
+++ b/header.php
@@ -36,7 +36,7 @@
 	</script>
 <?php } ?>
 </head>
-<body <?php $page_slug = $post->post_name; body_class($page_slug); ?>>
+<body <?php body_class( roots_detect_slug() ); ?>>
 	<?php roots_wrap_before(); ?>
 	<div id="wrap" class="container" role="document">
 	<?php roots_header_before(); ?>


### PR DESCRIPTION
Using this new function, we'd be able to detect the slug in a more
assorted and cleaner fashion. I made this to use with various projects I've been working on, and the slug was always imperative for me to add to the body class, which isn't solely detected with $post->post_name.
