### PR TITLE
Fix register sidebars so child themes can unregister them.

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -2,7 +2,7 @@
     <footer id="content-info" class="<?php global $roots_options; echo $roots_options['container_class']; ?>" role="contentinfo">
       <?php roots_footer_inside(); ?>
       <div class="container">
-        <?php dynamic_sidebar("Footer"); ?>
+        <?php dynamic_sidebar('roots-footer'); ?>
         <p class="copy"><small>&copy; <?php echo date('Y'); ?> <?php bloginfo('name'); ?></small></p>
       </div>
     </footer>

--- a/functions.php
+++ b/functions.php
@@ -65,16 +65,35 @@ function roots_setup() {
 
 add_action('after_setup_theme', 'roots_setup');
 
-// create widget areas: sidebar, footer
-$sidebars = array('Sidebar', 'Footer');
-foreach ($sidebars as $sidebar) {
-  register_sidebar(array('name'=> $sidebar,
-    'before_widget' => '<article id="%1$s" class="widget %2$s"><div class="container">',
-    'after_widget' => '</div></article>',
-    'before_title' => '<h3>',
-    'after_title' => '</h3>'
-  ));
+/**
+ * Register default roots sidebars.
+ * Hook into 'widgets_init' function with a lower priority in your child
+ * theme to remove these sidebars.
+ */
+function roots_register_sidebars() {
+  register_sidebar(
+    array(
+      'id'=> 'roots-sidebar',  
+      'name' => __('Sidebar', 'roots'),
+      'description' => __('Sidebar', 'roots'),
+      'before_widget' => '<article id="%1$s" class="widget %2$s"><div class="container">',
+      'after_widget' => '</div></article>',
+      'before_title' => '<h3>',
+      'after_title' => '</h3>'
+    ));
+  register_sidebar(
+    array(
+      'id'=> 'roots-footer',  
+      'name' => __('Footer', 'roots'),
+      'description' => __('Footer', 'roots'),
+      'before_widget' => '<article id="%1$s" class="widget %2$s"><div class="container">',
+      'after_widget' => '</div></article>',
+      'before_title' => '<h3>',
+      'after_title' => '</h3>'
+    ));
 }
+
+add_action( 'widgets_init', 'roots_register_sidebars' );
 
 // return post entry meta information
 function roots_entry_meta() {

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,1 +1,1 @@
-<?php dynamic_sidebar("Sidebar"); ?>
+<?php dynamic_sidebar('roots-sidebar'); ?>


### PR DESCRIPTION
Change to register sidebars using the widgets_init hook which allows a child theme to hook widgets_init with a higher priority so we can remove the sidebars. It also explicitly defines the id field to follow best practices so the id's aren't set to numeric by WordPress. Check out the following link for more info:

http://justintadlock.com/archives/2010/11/08/sidebars-in-wordpress
