### PR TITLE
Get the best of both worlds: require_once and locate_template

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2,14 +2,14 @@
 
 if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
 
-require_once get_template_directory() . '/inc/roots-activation.php';  // activation
-require_once get_template_directory() . '/inc/roots-options.php';     // theme options
-require_once get_template_directory() . '/inc/roots-cleanup.php';     // cleanup
-require_once get_template_directory() . '/inc/roots-htaccess.php';    // rewrites for assets, h5bp htaccess
-require_once get_template_directory() . '/inc/roots-hooks.php';     // hooks
-require_once get_template_directory() . '/inc/roots-actions.php';     // actions
-require_once get_template_directory() . '/inc/roots-widgets.php';     // widgets
-require_once get_template_directory() . '/inc/roots-custom.php';    // custom functions
+require_once locate_template( '/inc/roots-activation.php' );  // activation
+require_once locate_template( '/inc/roots-options.php' );     // theme options
+require_once locate_template( '/inc/roots-cleanup.php' );     // cleanup
+require_once locate_template( '/inc/roots-htaccess.php' );    // rewrites for assets, h5bp htaccess
+require_once locate_template( '/inc/roots-hooks.php' );     // hooks
+require_once locate_template( '/inc/roots-actions.php' );     // actions
+require_once locate_template( '/inc/roots-widgets.php' );     // widgets
+require_once locate_template( '/inc/roots-custom.php' );    // custom functions
 
 $roots_options = roots_get_theme_options();
 


### PR DESCRIPTION
A while back, all the template files included at the beginning of `functions.php` were switched to the format

`locate_template('inc/roots-somefile.php', true, true);`

so that child themes could override them. This fit neatly into my theme development workflow, since I could override what I needed in the `childtheme/inc/` directory, and I didn't have to worry about merging changes from upstream into my customized child theme.

In retlehs/roots@0d537df73e587e070f04fb98a91507888942ac8b the method was reverted to require_once because of "unexpected behavior" -- I'm guessing that `locate_template()` has problems with variable scope.

But can't we have the best of both worlds? `locate_template()` doesn't have to be used to actually include the php script; the default behavior is search `STYLESHEETPATH` and then `TEMPLATEPATH` for a script and return the filename as a string. One could format all the statements in the form:

`require_once locate_template('inc/roots-somefile.php');`

and both have predictable variable scope _and_ make it easy to override files.

Credit for the idea: http://wordpress.stackexchange.com/questions/4462/passing-variables-through-locate-template
