### PR TITLE
Chrome frame install script missing http protocol.

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -13,7 +13,7 @@
 <?php roots_footer(); ?>
 
   <!--[if lt IE 7]>
-    <script defer src="//ajax.googleapis.com/ajax/libs/chrome-frame/1.0.3/CFInstall.min.js"></script>
+    <script defer src="http://ajax.googleapis.com/ajax/libs/chrome-frame/1.0.3/CFInstall.min.js"></script>
     <script defer>window.attachEvent('onload',function(){CFInstall.check({mode:'overlay'})})</script>
   <![endif]-->
 


### PR DESCRIPTION
Chrome frame install script missing http protocol. This results in it not loading.

To test, view page in internet explorer 6 - you should get prompt to load chrome frame.
