### PR TITLE
Ending #wrap div earlier (before <footer>) in footer.php

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,4 +1,6 @@
 
+  </div><!-- /#wrap -->
+  
     <?php roots_footer_before(); ?>
     <footer id="content-info" class="<?php echo WRAP_CLASSES; ?>" role="contentinfo">
       <?php roots_footer_inside(); ?>
@@ -6,8 +8,6 @@
       <p class="copy"><small>&copy; <?php echo date('Y'); ?> <?php bloginfo('name'); ?></small></p>
     </footer>
     <?php roots_footer_after(); ?>
-
-  </div><!-- /#wrap -->
 
   <?php wp_footer(); ?>
   <?php roots_footer(); ?>


### PR DESCRIPTION
This makes more sense to me because the header isn't included in #wrap and because #wrap subjects anything inside it to container margins; currently these margins get in the way of the design of elements added using the `roots_footer_before` or `roots_footer_after` hooks.

Elements added using `roots_header_before`, `roots_header_after`, `roots_footer_before` or `roots_footer_after` shouldn't be wrapped by a div that imposes styling on them by default.
