### PR TITLE
Search redirect Buddypress

### DIFF
--- a/inc/roots-cleanup.php
+++ b/inc/roots-cleanup.php
@@ -3,15 +3,13 @@
 // redirect /?s to /search/
 // http://txfx.net/wordpress-plugins/nice-search/
 function roots_nice_search_redirect() {
-  if (is_search() && strpos($_SERVER['REQUEST_URI'], '/wp-admin/') === false && strpos($_SERVER['REQUEST_URI'], '/search/') === false) {
+  if (is_search() && !defined('BP_VERSION') && strpos($_SERVER['REQUEST_URI'], '/wp-admin/') === false && strpos($_SERVER['REQUEST_URI'], '/search/') === false) {
     wp_redirect(home_url('/search/' . str_replace(array(' ', '%20'), array('+', '+'), urlencode(get_query_var('s')))), 301);
       exit();
   }
 }
 
-if(!defined('BP_VERSION')){ //if buddypress is active, do not redirect search... buddypress doesn't like it.
   add_action('template_redirect', 'roots_nice_search_redirect');
-}
 
 function roots_search_query($escaped = true) {
   $query = apply_filters('roots_search_query', get_query_var('s'));


### PR DESCRIPTION
Still new to github, so i apologies if i do this pull request thing wrong, but to get roots compatible with buddypress (see #236) i wrapped the search redirect action with !defined('BP_VERSION') to ensure that it reverts to the ugly url structure if buddypress is active...

Just a quick fix until we figure out how to get it working properly with BP. atleast this way buddypress owners can still use the search feature (i've been looking through the bp code, but i cant seem to pinpoint a proper fix yet to get clean urls working)
