### PR TITLE
Fix loop-page.php so that posts titles are links

### DIFF
--- a/loop-page.php
+++ b/loop-page.php
@@ -3,7 +3,7 @@
   <?php roots_post_before(); ?>
     <?php roots_post_inside_before(); ?>
       <div class="page-header">
-      	<h1><?php the_title(); ?></h1>
+        <h1><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h1>
       </div>
       <?php the_content(); ?>
       <?php wp_link_pages(array('before' => '<nav class="pagination">', 'after' => '</nav>')); ?>


### PR DESCRIPTION
I'm not using a custom home page for my blog.  I just want article snippets and links like Wordpress does out of the box.  I just changed loop-page.php so it does that.  Before the titles weren't clickable.
