### PR TITLE
Login Issue #301 - quick fix 

### DIFF
--- a/inc/roots-scripts.php
+++ b/inc/roots-scripts.php
@@ -9,12 +9,13 @@ function roots_scripts() {
 
 add_action('wp_enqueue_scripts', 'roots_scripts');
 
-if (basename($_SERVER['PHP_SELF']) != 'wp-login.php' && !is_admin()) {
+if (!is_admin()) {
   add_action('wp_print_scripts', 'roots_print_scripts');
 }
 
 function roots_print_scripts() {
   global $wp_scripts;
+  if (! isset($wp_scripts)) return;
 
   $wp_scripts->all_deps($wp_scripts->queue);
   $scripts = $locales = array();


### PR DESCRIPTION
The scene is, `is_admin()` function returns false on login page and on non-dashboard pages. There is a hook using (not)`is_admin()` condition to add theme related scripts. But the site breaks down on `wp-login.php` page as the global variable `$wp_scripts` used in the function is showing `null` on `wp-login.php` page. Except this one page, theme scripts are being added properly to non-admin pages properly.

This is a quick fix, I don't know if it is the best solution for this problem, but at least I could log-in to my live site with this.
