### PR TITLE
&times; HTML entity

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -11,7 +11,7 @@
 
       <?php if ($comment->comment_approved == '0') { ?>
         <div class="alert alert-block fade in">
-          <a class="close" data-dismiss="alert">×</a>
+          <a class="close" data-dismiss="alert">&times;</a>
           <p><?php _e('Your comment is awaiting moderation.', 'roots'); ?></p>
         </div>
       <?php } ?>


### PR DESCRIPTION
Those of us who maybe have a little bit of a… problem about typographical correctness would rather see roots use × (the `&times;` HTML entity) instead of the letter x when it displays the close button of the alert blocks. The attached pull goes about that.
