### PR TITLE
Introduce intital-scale=1.0 viewport meta and max-width:100% css fix for bootstrap 2.0.2

### DIFF
--- a/css/bootstrap.css
+++ b/css/bootstrap.css
@@ -7,7 +7,7 @@ a:hover,a:active{outline:0;}
 sub,sup{position:relative;font-size:75%;line-height:0;vertical-align:baseline;}
 sup{top:-0.5em;}
 sub{bottom:-0.25em;}
-img{height:auto;border:0;-ms-interpolation-mode:bicubic;vertical-align:middle;}
+img{height:auto;border:0;-ms-interpolation-mode:bicubic;vertical-align:middle;max-width:100%;}
 button,input,select,textarea{margin:0;font-size:100%;vertical-align:middle;}
 button,input{*overflow:visible;line-height:normal;}
 button::-moz-focus-inner,input::-moz-focus-inner{padding:0;border:0;}

--- a/header.php
+++ b/header.php
@@ -8,7 +8,7 @@
 
   <title><?php wp_title('|', true, 'right'); bloginfo('name'); ?></title>
 
-  <meta name="viewport" content="width=device-width">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <script src="<?php echo get_template_directory_uri(); ?>/js/libs/modernizr-2.5.3.min.js"></script>
 


### PR DESCRIPTION
As seen in the [Bootstrap Documentation](http://twitter.github.com/bootstrap/scaffolding.html#responsive), a viewport of initial-scale=1.0 is recommended. 

This enables a scrolling uncollapsed navbar when viewing Roots sites on a Landscape iPad.

Bootstrap 2.0.2 also took away the `max-width:100%;` CSS which allows images to be responsive as a fix for Google Maps. Mark Otto reverted on this decision and will implement in 2.0.3: https://github.com/twitter/bootstrap/issues/2573#issuecomment-4653781
