### PR TITLE
Missing reference to main.js

### DIFF
--- a/inc/roots-scripts.php
+++ b/inc/roots-scripts.php
@@ -27,7 +27,7 @@ function roots_scripts() {
   wp_register_script('roots_plugins', get_template_directory_uri() . '/js/plugins.js', false, null, false);
   wp_register_script('roots_main', get_template_directory_uri() . '/js/main.js', false, null, false);
   wp_enqueue_script('roots_plugins');
-  wp_enqueue_script('roots_script');
+  wp_enqueue_script('roots_main');
 }
 
 add_action('wp_enqueue_scripts', 'roots_scripts', 100);


### PR DESCRIPTION
The roots-scripts.php file is still pointing to roots_script that no longer exists. Patched to the new roots_main.
