### PR TITLE
Stylesheet Versioning, Caching

### DIFF
--- a/inc/roots-scripts.php
+++ b/inc/roots-scripts.php
@@ -3,13 +3,13 @@
 function roots_scripts() {
   // Not included by default since Bootstrap's reset supersedes h5bp's. Include if you aren't using Bootstrap. 
   //wp_enqueue_style('roots_style', get_template_directory_uri() . '/css/style.css', false, null);
-  wp_enqueue_style('roots_bootstrap_style', get_template_directory_uri() . '/css/bootstrap.css');
+  wp_enqueue_style('roots_bootstrap_style', get_template_directory_uri() . '/css/bootstrap.css', false, null);
 
   if (BOOTSTRAP_RESPONSIVE) {
-    wp_enqueue_style('roots_bootstrap_responsive_style', get_template_directory_uri() . '/css/bootstrap-responsive.css', array('roots_bootstrap_style'));
+    wp_enqueue_style('roots_bootstrap_responsive_style', get_template_directory_uri() . '/css/bootstrap-responsive.css', array('roots_bootstrap_style'), null);
   }
 
-  wp_enqueue_style('roots_app_style', get_template_directory_uri() . '/css/app.css', false);
+  wp_enqueue_style('roots_app_style', get_template_directory_uri() . '/css/app.css', false, null);
 
   if (is_child_theme()) {
     wp_enqueue_style('roots_child_style', get_stylesheet_uri());


### PR DESCRIPTION
I'd like to recommend removing the WordPress version numbers on the stylesheets. First, it gets rid of more junk. Second, version numbers are already being removed on the scripts. Third, it's better caching (see below).

Google - Make the Web Faster - Leverage proxy caching
https://developers.google.com/speed/docs/best-practices/caching#LeverageProxyCaching

> ### Recommendations
> 
> **_Don't include a query string in the URL for static resources.**_
> Most proxies, most notably Squid up through version 3.0, do not cache resources with a "?" in their URL even if a Cache-control: public header is present in the response. To enable proxy caching for these resources, remove query strings from references to static resources, and instead encode the parameters into the file names themselves.
