### PR TITLE
This adds the option to enable or disable the relative urls functionality

### DIFF
--- a/inc/roots-cleanup.php
+++ b/inc/roots-cleanup.php
@@ -65,7 +65,19 @@ function roots_fix_duplicate_subfolder_urls($input) {
   return $output;
 }
 
-if (!is_admin() && !in_array($GLOBALS['pagenow'], array('wp-login.php', 'wp-register.php'))) {
+// remove root relative URLs on any attachments in the feed
+function roots_root_relative_attachment_urls() {
+  if (!is_feed()) {
+    add_filter('wp_get_attachment_url', 'roots_root_relative_url');
+    add_filter('wp_get_attachment_link', 'roots_root_relative_url');
+  }
+}
+
+function enable_root_relative_urls() {
+  return !(is_admin() && in_array($GLOBALS['pagenow'], array('wp-login.php', 'wp-register.php'))) && ROOT_RELATIVE_URLS;
+}
+
+if (enable_root_relative_urls()) {
   $tags = array(
     'bloginfo_url',
     'theme_root_uri',
@@ -91,17 +103,9 @@ if (!is_admin() && !in_array($GLOBALS['pagenow'], array('wp-login.php', 'wp-regi
 
   add_filter('script_loader_src', 'roots_fix_duplicate_subfolder_urls');
   add_filter('style_loader_src', 'roots_fix_duplicate_subfolder_urls');
-}
 
-// remove root relative URLs on any attachments in the feed
-function roots_root_relative_attachment_urls() {
-  if (!is_feed()) {
-    add_filter('wp_get_attachment_url', 'roots_root_relative_url');
-    add_filter('wp_get_attachment_link', 'roots_root_relative_url');
-  }
+  add_action('pre_get_posts', 'roots_root_relative_attachment_urls');
 }
-
-add_action('pre_get_posts', 'roots_root_relative_attachment_urls');
 
 // set lang="en" as default (rather than en-US)
 function roots_language_attributes() {

--- a/inc/roots-config.php
+++ b/inc/roots-config.php
@@ -1,5 +1,6 @@
 <?php
 
+define('ROOT_RELATIVE_URLS',   true);
 define('POST_EXCERPT_LENGTH',  40);
 define('BOOTSTRAP_RESPONSIVE', true);
 define('WRAP_CLASSES',         'container');


### PR DESCRIPTION
Let's try this again, this time properly:

I added a true/false switch called <code>ROOT_RELATIVE_URLS</code> to enable/disable the relative urls in <code>roots_config.php</code>. Relative urls are still enabled by default.

I moved the conditions that previously triggered the relative urls functionality to a new function <code>enable_root_relative_urls()</code> which returns a boolean true/false.
I replaced the conditions i moved by a test for <code>enable_root_relative_urls()</code> true/false value.

Sorry about the mess with the other branch earlier, i'm still pretty new to this git thing :)
