### PR TITLE
Remove 'Search Roots' text from before search form.

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -1,5 +1,4 @@
 <form role="search" method="get" id="searchform" class="form-search" action="<?php echo home_url('/'); ?>">
-  <label class="hide-text" for="s"><?php _e('Search for:', 'roots'); ?></label>
   <input type="text" value="" name="s" id="s" class="search-query" placeholder="<?php _e('Search', 'roots'); ?> <?php bloginfo('name'); ?>">
   <input type="submit" id="searchsubmit" value="<?php _e('Search', 'roots'); ?>" class="btn">
 </form>


### PR DESCRIPTION
...'); ?></label>

By default it breaks the sidebar look as it doesn't fit correctly, and search is very self explanatory I feel.
