### PR TITLE
Fix lowercase reference to $WP_User->ID on roots_entry_meta()

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -3,5 +3,5 @@
 // Return post entry meta information
 function roots_entry_meta() {
   echo '<time class="updated" datetime="'. get_the_time('c') .'" pubdate>'. sprintf(__('Posted on %s at %s.', 'roots'), get_the_date(), get_the_time()) .'</time>';
-  echo '<p class="byline author vcard">'. __('Written by', 'roots') .' <a href="'. get_author_posts_url(get_the_author_meta('id')) .'" rel="author" class="fn">'. get_the_author() .'</a></p>';
+  echo '<p class="byline author vcard">'. __('Written by', 'roots') .' <a href="'. get_author_posts_url(get_the_author_meta('ID')) .'" rel="author" class="fn">'. get_the_author() .'</a></p>';
 }


### PR DESCRIPTION
I was getting some error messages with `roots_entry_meta()` with debug mode on, the lowercase id attribute is deprecated since wp 2.1 (but it wasn't throwing this message until 3.4) 

http://core.trac.wordpress.org/ticket/3152
