### PR TITLE
Allow author to control archive penname from dashboard.

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -20,7 +20,7 @@
               } elseif (is_author()) {
                 global $post;
                 $author_id = $post->post_author;
-                printf(__('Author Archives: %s', 'roots'), get_the_author_meta('user_nicename', $author_id));
+                printf(__('Author Archives: %s', 'roots'), get_the_author_meta('display_name', $author_id));
               } else {
                 single_cat_title();
               }


### PR DESCRIPTION
Substituting 'user_nicename' with 'display_name' will allow the author to change their penname using the "Display name publicly as" from the profile dashboard.
