### PR TITLE
Menu args filter assumes items_wrap should be unordered list

### DIFF
--- a/inc/cleanup.php
+++ b/inc/cleanup.php
@@ -589,7 +589,10 @@ class Roots_Navbar_Nav_Walker extends Walker_Nav_Menu {
  */
 function roots_nav_menu_args($args = '') {
   $roots_nav_menu_args['container']  = false;
-  $roots_nav_menu_args['items_wrap'] = '<ul class="%2$s">%3$s</ul>';
+
+  if (!$args['items_wrap']) {
+    $roots_nav_menu_args['items_wrap'] = '<ul class="%2$s">%3$s</ul>';
+  }
 
   if ($args['walker'] == new Roots_Navbar_Nav_Walker()) {
     $roots_nav_menu_args['depth'] = 2;
@@ -722,4 +725,3 @@ function roots_embed_wrap($cache, $url, $attr = '', $post_ID = '') {
 
 add_filter('embed_oembed_html', 'roots_embed_wrap', 10, 4);
 add_filter('embed_googlevideo', 'roots_embed_wrap', 10, 2);
-


### PR DESCRIPTION
Hi,

Some people have been complaining that my dropdown menu plugin is broken with the roots theme. The problem is you force the value of the 'items_wrap' argument.

My plugin changes 'items_wrap' to a `<select>` tag so this pull request just adds a check to see if items_wrap is set already, if so it will ignore the override.

Cheers :)
