### PR TITLE
Dropdown Bug

### DIFF
--- a/lib/cleanup.php
+++ b/lib/cleanup.php
@@ -471,7 +471,7 @@ class Roots_Nav_Walker extends Walker_Nav_Menu {
     $attributes .= ! empty($item->target)     ? ' target="' . esc_attr($item->target    ) .'"' : '';
     $attributes .= ! empty($item->xfn)        ? ' rel="'    . esc_attr($item->xfn       ) .'"' : '';
     $attributes .= ! empty($item->url)        ? ' href="'   . esc_attr($item->url       ) .'"' : '';
-    $attributes .= ($args->has_children)    ? ' class="dropdown-toggle" data-toggle="dropdown"' : '';
+    $attributes .= ($args->has_children)    ? ' class="dropdown-toggle" data-toggle="dropdown"  data-target="#"' : '';
 
     $item_output  = $args->before;
     $item_output .= '<a'. $attributes .'>';


### PR DESCRIPTION
Due to updates (jQuery and Bootstrap), dropdowns stopped working because
of missing "data-target" (see
http://twitter.github.com/bootstrap/javascript.html#dropdowns)
