### PR TITLE
Dropdown Bug - another try

### DIFF
--- a/lib/cleanup.php
+++ b/lib/cleanup.php
@@ -471,7 +471,7 @@ class Roots_Nav_Walker extends Walker_Nav_Menu {
     $attributes .= ! empty($item->target)     ? ' target="' . esc_attr($item->target    ) .'"' : '';
     $attributes .= ! empty($item->xfn)        ? ' rel="'    . esc_attr($item->xfn       ) .'"' : '';
     $attributes .= ! empty($item->url)        ? ' href="'   . esc_attr($item->url       ) .'"' : '';
-    $attributes .= ($args->has_children)    ? ' class="dropdown-toggle" data-toggle="dropdown"' : '';
+    $attributes .= ($args->has_children)    ? ' class="dropdown-toggle" data-toggle="dropdown" data-target="#"' : '';
 
     $item_output  = $args->before;
     $item_output .= '<a'. $attributes .'>';


### PR DESCRIPTION
I hope, it worked now (used to web interface to be sure - sorry!)...

when a dropdown parent contains a link itself, a `data-target="#"` is needed
