### PR TITLE
Consistent use of PHP alternative syntax

### DIFF
--- a/base.php
+++ b/base.php
@@ -17,11 +17,11 @@
       <div id="main" class="<?php roots_main_class(); ?>" role="main">
         <?php include roots_template_path(); ?>
       </div>
-      <?php if (roots_sidebar()) { ?>
+      <?php if (roots_sidebar()) : ?>
       <aside id="sidebar" class="<?php roots_sidebar_class(); ?>" role="complementary">
         <?php get_template_part('templates/sidebar'); ?>
       </aside>
-      <?php } ?>
+      <?php endif; ?>
     </div><!-- /#content -->
   </div><!-- /#wrap -->
 

--- a/templates/comments.php
+++ b/templates/comments.php
@@ -9,12 +9,12 @@
         <?php edit_comment_link(__('(Edit)', 'roots'), '', ''); ?>
       </header>
 
-      <?php if ($comment->comment_approved == '0') { ?>
+      <?php if ($comment->comment_approved == '0') : ?>
         <div class="alert alert-block fade in">
           <a class="close" data-dismiss="alert">&times;</a>
           <p><?php _e('Your comment is awaiting moderation.', 'roots'); ?></p>
         </div>
-      <?php } ?>
+      <?php endif; ?>
 
       <section class="comment">
         <?php comment_text() ?>
@@ -25,18 +25,16 @@
     </article>
 <?php } ?>
 
-<?php if (post_password_required()) { ?>
+<?php if (post_password_required()) : ?>
   <section id="comments">
     <div class="alert alert-block fade in">
       <a class="close" data-dismiss="alert">&times;</a>
       <p><?php _e('This post is password protected. Enter the password to view comments.', 'roots'); ?></p>
     </div>
   </section><!-- /#comments -->
-<?php
-  return;
-} ?>
+<?php endif; ?>
 
-<?php if (have_comments()) { ?>
+<?php if (have_comments()) : ?>
   <section id="comments">
     <h3><?php printf(_n('One Response to &ldquo;%2$s&rdquo;', '%1$s Responses to &ldquo;%2$s&rdquo;', get_comments_number(), 'roots'), number_format_i18n(get_comments_number()), get_the_title()); ?></h3>
 
@@ -44,56 +42,56 @@
       <?php wp_list_comments(array('callback' => 'roots_comment')); ?>
     </ol>
 
-    <?php if (get_comment_pages_count() > 1 && get_option('page_comments')) { // are there comments to navigate through ?>
+    <?php if (get_comment_pages_count() > 1 && get_option('page_comments')) : // are there comments to navigate through ?>
       <nav id="comments-nav" class="pager">
         <div class="previous"><?php previous_comments_link(__('&larr; Older comments', 'roots')); ?></div>
         <div class="next"><?php next_comments_link(__('Newer comments &rarr;', 'roots')); ?></div>
       </nav>
 
-    <?php } // check for comment navigation ?>
+    <?php endif; // check for comment navigation ?>
 
-    <?php if (!comments_open() && !is_page() && post_type_supports(get_post_type(), 'comments')) { ?>
+    <?php if (!comments_open() && !is_page() && post_type_supports(get_post_type(), 'comments')) : ?>
       <div class="alert alert-block fade in">
         <a class="close" data-dismiss="alert">&times;</a>
         <p><?php _e('Comments are closed.', 'roots'); ?></p>
       </div>
-    <?php } ?>
+    <?php endif; ?>
   </section><!-- /#comments -->
-<?php } ?>
+<?php endif; ?>
 
-<?php if (!have_comments() && !comments_open() && !is_page() && post_type_supports(get_post_type(), 'comments')) { ?>
+<?php if (!have_comments() && !comments_open() && !is_page() && post_type_supports(get_post_type(), 'comments')) : ?>
   <section id="comments">
     <div class="alert alert-block fade in">
       <a class="close" data-dismiss="alert">&times;</a>
       <p><?php _e('Comments are closed.', 'roots'); ?></p>
     </div>
   </section><!-- /#comments -->
-<?php } ?>
+<?php endif; ?>
 
-<?php if (comments_open()) { ?>
+<?php if (comments_open()) : ?>
   <section id="respond">
     <h3><?php comment_form_title(__('Leave a Reply', 'roots'), __('Leave a Reply to %s', 'roots')); ?></h3>
     <p class="cancel-comment-reply"><?php cancel_comment_reply_link(); ?></p>
-    <?php if (get_option('comment_registration') && !is_user_logged_in()) { ?>
+    <?php if (get_option('comment_registration') && !is_user_logged_in()) : ?>
       <p><?php printf(__('You must be <a href="%s">logged in</a> to post a comment.', 'roots'), wp_login_url(get_permalink())); ?></p>
-    <?php } else { ?>
+    <?php else : ?>
       <form action="<?php echo get_option('siteurl'); ?>/wp-comments-post.php" method="post" id="commentform">
-        <?php if (is_user_logged_in()) { ?>
+        <?php if (is_user_logged_in()) : ?>
           <p><?php printf(__('Logged in as <a href="%s/wp-admin/profile.php">%s</a>.', 'roots'), get_option('siteurl'), $user_identity); ?> <a href="<?php echo wp_logout_url(get_permalink()); ?>" title="<?php __('Log out of this account', 'roots'); ?>"><?php _e('Log out &raquo;', 'roots'); ?></a></p>
-        <?php } else { ?>
+        <?php else : ?>
           <label for="author"><?php _e('Name', 'roots'); if ($req) _e(' (required)', 'roots'); ?></label>
           <input type="text" class="text" name="author" id="author" value="<?php echo esc_attr($comment_author); ?>" size="22" tabindex="1" <?php if ($req) echo "aria-required='true'"; ?>>
           <label for="email"><?php _e('Email (will not be published)', 'roots'); if ($req) _e(' (required)', 'roots'); ?></label>
           <input type="email" class="text" name="email" id="email" value="<?php echo esc_attr($comment_author_email); ?>" size="22" tabindex="2" <?php if ($req) echo "aria-required='true'"; ?>>
           <label for="url"><?php _e('Website', 'roots'); ?></label>
           <input type="url" class="text" name="url" id="url" value="<?php echo esc_attr($comment_author_url); ?>" size="22" tabindex="3">
-        <?php } ?>
+        <?php endif; ?>
         <label for="comment"><?php _e('Comment', 'roots'); ?></label>
         <textarea name="comment" id="comment" class="input-xlarge" tabindex="4"></textarea>
         <p><input name="submit" class="btn btn-primary" type="submit" id="submit" tabindex="5" value="<?php _e('Submit Comment', 'roots'); ?>"></p>
         <?php comment_id_fields(); ?>
         <?php do_action('comment_form', $post->ID); ?>
       </form>
-    <?php } // if registration required and not logged in ?>
+    <?php endif; // if registration required and not logged in ?>
   </section><!-- /#respond -->
-<?php } ?>
+<?php endif; ?>

--- a/templates/content.php
+++ b/templates/content.php
@@ -1,10 +1,10 @@
-<?php if (!have_posts()) { ?>
+<?php if (!have_posts()) : ?>
   <div class="alert alert-block fade in">
     <a class="close" data-dismiss="alert">&times;</a>
     <p><?php _e('Sorry, no results were found.', 'roots'); ?></p>
   </div>
   <?php get_search_form(); ?>
-<?php } ?>
+<?php endif; ?>
 
 <?php while (have_posts()) : the_post(); ?>
   <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -21,9 +21,9 @@
   </article>
 <?php endwhile; ?>
 
-<?php if ($wp_query->max_num_pages > 1) { ?>
+<?php if ($wp_query->max_num_pages > 1) : ?>
   <nav id="post-nav" class="pager">
     <div class="previous"><?php next_posts_link(__('&larr; Older posts', 'roots')); ?></div>
     <div class="next"><?php previous_posts_link(__('Newer posts &rarr;', 'roots')); ?></div>
   </nav>
-<?php } ?>
+<?php endif; ?>


### PR DESCRIPTION
PHP alternative syntax is more readable when used in templates mixed with WordPress.
