### PR TITLE
New nav walker support for CSS dividers and nav-header

### DIFF
--- a/page.php
+++ b/page.php
@@ -1,3 +1,2 @@
 <?php get_template_part('templates/page', 'header'); ?>
 <?php get_template_part('templates/content', 'page'); ?>
-<?php comments_template('/templates/comments.php'); ?>


### PR DESCRIPTION
Custom menu now deals with "divider", "divider-vertical" and "nav-header" CSS classes as expected. Title is used for the "nav-header" heading. N.B. To add CSS classes to menus please select the relevant checkbox within "screen options" on the nav menu admin page.
