### PR TITLE
New nav walker support for CSS dividers and nav-header

### DIFF
--- a/lib/cleanup.php
+++ b/lib/cleanup.php
@@ -435,14 +435,14 @@ class Roots_Nav_Walker extends Walker_Nav_Menu {
       $item_html = str_replace('<a', '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"', $item_html);
       $item_html = str_replace('</a>', ' <b class="caret"></b></a>', $item_html);
     }
-    elseif (in_array('divider-vertical',$item->classes)) {
+    elseif (in_array('divider-vertical', $item->classes)) {
       $item_html = '<li class="divider-vertical">';
     }  
-    elseif (in_array('divider',$item->classes)) {
+    elseif (in_array('divider', $item->classes)) {
       $item_html = '<li class="divider">';
     }
-    elseif (in_array('nav-header',$item->classes)) {
-      $item_html = '<li class="nav-header">'. $item->title;
+    elseif (in_array('nav-header', $item->classes)) {
+      $item_html = '<li class="nav-header">' . $item->title;
     }
 
     $output .= $item_html;


### PR DESCRIPTION
The new and improved nav walker now deals with "divider", "divider-vertical" and "nav-header" CSS classes as expected. Title is used for the "nav-header" heading. N.B. To add CSS classes to menus please select the relevant checkbox within "screen options" on the nav menu admin page.
