### PR TITLE
Fix bug on roots_fix_duplicate_subfolder_urls 

### DIFF
--- a/lib/cleanup.php
+++ b/lib/cleanup.php
@@ -160,7 +160,7 @@ function roots_fix_duplicate_subfolder_urls($input) {
   $output = roots_root_relative_url($input);
   preg_match_all('!([^/]+)/([^/]+)!', $output, $matches);
 
-  if (isset($matches[1]) && isset($matches[2])) {
+  if (isset($matches[1][0]) && isset($matches[2][0])) {
     if ($matches[1][0] === $matches[2][0]) {
       $output = substr($output, strlen($matches[1][0]) + 1);
     }


### PR DESCRIPTION
roots_fix_duplicate_subfolder_urls function checked if $matches[1] & $matches[2] were set, but next line operates on $matches[1][0] & $matches[2][0], so under certain circumstances, you get the following Notice: Undefined offset: 0.

Now it checks for the [0] offsets from the start.

I only get this error when the WP e-commerce plugin is active

Sample below:
INPUT: 
http://site.loc/index.php?wpsc_user_dynamic_css=true&category&ver=3.8.8.5.571548

OUTPUT:
/index.php?wpsc_user_dynamic_css=true&category&ver=3.8.8.5.571548

MATCHES:
Array
(
    [0] => Array
        (
        )

```
[1] => Array
    (
    )

[2] => Array
    (
    )
```

)
