### PR TITLE
Nav walker support for unset menu. 

### DIFF
--- a/lib/nav.php
+++ b/lib/nav.php
@@ -28,10 +28,10 @@ class Roots_Nav_Walker extends Walker_Nav_Menu {
       $item_html = str_replace('<a', '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"', $item_html);
       $item_html = str_replace('</a>', ' <b class="caret"></b></a>', $item_html);
     }
-    elseif (stristr($item_html,'li class="divider')) {
+    elseif (stristr($item_html, 'li class="divider')) {
       $item_html = preg_replace('/<a[^>]*>.*?<\/a>/iU', '', $item_html);    
     }
-    elseif (stristr($item_html,'li class="nav-header')) {
+    elseif (stristr($item_html, 'li class="nav-header')) {
       $item_html = preg_replace('/<a[^>]*>(.*)<\/a>/iU', '$1', $item_html);
     }   
 


### PR DESCRIPTION
Previous nav walker resulted in an error when no menu is set. This does not.
The fix supports supplementary classes for styling i.e. nav-header nav-header-blue. 
N.B. Bootstrap classes (nav-header, divider, divider-vertical) must be added first.

See also: #551 #563
