### PR TITLE
Preserve the search query in the search input 

### DIFF
--- a/templates/searchform.php
+++ b/templates/searchform.php
@@ -1,5 +1,5 @@
 <form role="search" method="get" id="searchform" class="form-search" action="<?php echo home_url('/'); ?>">
   <label class="hide" for="s"><?php _e('Search for:', 'roots'); ?></label>
-  <input type="text" value="" name="s" id="s" class="search-query" placeholder="<?php _e('Search', 'roots'); ?> <?php bloginfo('name'); ?>">
+  <input type="text" value="<?php if (is_search()) { echo get_search_query(); } ?>" name="s" id="s" class="search-query" placeholder="<?php _e('Search', 'roots'); ?> <?php bloginfo('name'); ?>">
   <input type="submit" id="searchsubmit" value="<?php _e('Search', 'roots'); ?>" class="btn">
 </form>


### PR DESCRIPTION
This allows people to alter the text instead of retyping their query upon re-searching.
