### PR TITLE
Improve the activation documentation page

### DIFF
--- a/doc/activation.md
+++ b/doc/activation.md
@@ -26,3 +26,10 @@ Create the Primary Navigation menu and set the location. This is normally handle
 ### Add pages to menu
 
 Add all published pages to the Primary Navigation. On a fresh install, this will add the new Home page and existing Sample Page to the navigation.
+
+## Troubleshooting
+
+If it's a fresh Wordpress installation you're trying to activate Roots for, you will be warned to make sure that your `.htaccess`
+file is writable. Such file, though, won't exist if you don't have already enabled permalinks.
+
+So, in case you see that error message, try opening Settings / Permalinks from your Wordpress Dashboard and enabling one of the options other than `Default`.


### PR DESCRIPTION
In a fresh WP installation—or one with permalinks not enabled—there won't be any .htaccess.

It might not be obvious to everyone, so it's probably worth mentioning.

This is a trivial change for which I didn't create a topic branch, but if you want it just say so.
