### PR TITLE
Roots granular watch

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
         tasks: 'js'
       },
       css: {
-        files: ['assets/css/less/*.less', 'assets/css/less/bootstrap/*.less'],
+        files: ['assets/css/less/**/*.less'],
         tasks: 'css'
       }
     }


### PR DESCRIPTION
Watch JS & Less separately and execute asset-specific tasks to avoid redundant compiles.
