### PR TITLE
Allow get_search_form() to be called more than once per request

### DIFF
--- a/lib/cleanup.php
+++ b/lib/cleanup.php
@@ -513,8 +513,10 @@ add_filter('request', 'roots_request_filter');
 /**
  * Tell WordPress to use searchform.php from the templates/ directory
  */
-function roots_get_search_form() {
-  locate_template('/templates/searchform.php', true, true);
+function roots_get_search_form($argument) {
+  if ($argument === '') {
+    locate_template('/templates/searchform.php', true, false);
+  }
 }
 
 add_filter('get_search_form', 'roots_get_search_form');


### PR DESCRIPTION
If you try to call get_search_form() more than once per request, it only renders it once. I make it work using a workaround to an upstream bug where an action and a filter have the same name ( http://core.trac.wordpress.org/ticket/19321 ).
