### PR TITLE
Relative URLs

### DIFF
--- a/lib/cleanup.php
+++ b/lib/cleanup.php
@@ -142,6 +142,13 @@ function roots_root_relative_url($input) {
     ),
     $input
   );
+  
+  // detect and correct for subdir installs
+  if($subdir = parse_url(home_url(), PHP_URL_PATH)) {
+  	if(substr($output, 0, strlen($subdir)) == (substr($output, strlen($subdir), strlen($subdir)))) {
+  		$output = substr($output, strlen($subdir));
+  	}
+  }
 
   return $output;
 }


### PR DESCRIPTION
Small fix for relative URLs where site_url != home_url. Also fixes multiple subdirectory in URL issue (at least in my tests). I have removed the "Terrible Workaround".

Problem was caused by home_url() being stripped early on, then later the site_url being prepended in functions like WP_Styles::_css_href(), before only the home_url was stripped again, missing the subdir. Could maybe be fixed in a cleaner way by simply changing WP core to prevent base_url being prepended to links where no site URL is present, could check for and add content_url instead where appropriate.

E.g. for home url example.com with WordPress install at example.com/wordpress, roots_root_relative_url() would strip example.com, WP_Styles::_css_href() would add example.com/wordpress, and then roots_root_relative_url() would strip example.com again, leaving /wordpress/... at the start of the URL.

Anyway, not sure if this fix applies to all cases, but it works for me and it's nice and simple.

RE: #395, #533, etc.
