### PR TITLE
Navbar items break if the menu depth is set to exclude children

### DIFF
--- a/lib/nav.php
+++ b/lib/nav.php
@@ -38,7 +38,7 @@ class Roots_Nav_Walker extends Walker_Nav_Menu {
   }
 
   function display_element($element, &$children_elements, $max_depth, $depth = 0, $args, &$output) {
-    $element->is_dropdown = !empty($children_elements[$element->ID]);
+    $element->is_dropdown =  ((!empty($children_elements[$element->ID]) && (($depth + 1) < $max_depth)));
 
     if ($element->is_dropdown) {
       if ($depth === 0) {


### PR DESCRIPTION
Navbar items with children broke if the menu depth excluded the children.
Such as: `wp_nav_menu(array('depth' => 1));` where 2nd level children exist
