### PR TITLE
Move ancient browser text to a function.

### DIFF
--- a/base.php
+++ b/base.php
@@ -1,7 +1,7 @@
 <?php get_template_part('templates/head'); ?>
 <body <?php body_class(); ?>>
 
-  <!--[if lt IE 7]><div class="alert">Your browser is <em>ancient!</em> <a href="http://browsehappy.com/">Upgrade to a different browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">install Google Chrome Frame</a> to experience this site.</div><![endif]-->
+  <?php echo roots_ancient_browser(); ?>
 
   <?php
     do_action('get_header');

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -86,6 +86,13 @@ function roots_title() {
 }
 
 /**
+* Ancient browser alert
+*/
+function roots_ancient_browser() {
+  return '<!--[if lt IE 7]><div class="alert">Your browser is <em>ancient!</em> <a href="http://browsehappy.com/">Upgrade to a different browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">install Google Chrome Frame</a> to experience this site.</div><![endif]-->';
+}
+
+/**
  * Show an admin notice if .htaccess isn't writable
  */
 function roots_htaccess_writable() {


### PR DESCRIPTION
I suggest we do this to better accomodate custom `base-*.php` templates that still want to include the check.
