### PR TITLE
is_dropdown can evaluate to true even if depth is not specified in wp_nav_menu() arguments

### DIFF
--- a/lib/nav.php
+++ b/lib/nav.php
@@ -38,7 +38,7 @@ class Roots_Nav_Walker extends Walker_Nav_Menu {
   }
 
   function display_element($element, &$children_elements, $max_depth, $depth = 0, $args, &$output) {
-    $element->is_dropdown = ((!empty($children_elements[$element->ID] ) && (($depth + 1 ) < $max_depth || ( $max_depth === 0 ))));
+    $element->is_dropdown = ((!empty($children_elements[$element->ID]) && (($depth + 1) < $max_depth || ($max_depth === 0))));
 
     if ($element->is_dropdown) {
       if ($depth === 0) {


### PR DESCRIPTION
is_dropdown can evaluate to true even if max_depth is 0. This is the WordPress default and implies that dropdowns are enabled. The current code seems to interperet $max_depth == 0 to mean dropdowns are disabled.

http://codex.wordpress.org/Function_Reference/wp_nav_menu :

<blockquote>$depth
(integer) (optional) How many levels of the hierarchy are to be included <strong>where 0 means all</strong>.</blockquote>
