### PR TITLE
Don't warn about unwritable htaccess if that option is disabled

### DIFF
--- a/lib/utils.php
+++ b/lib/utils.php
@@ -95,7 +95,9 @@ function roots_htaccess_writable() {
     }
   }
 }
-add_action('admin_init', 'roots_htaccess_writable');
+if (current_theme_supports('h5bp-htaccess')) {
+  add_action('admin_init', 'roots_htaccess_writable');
+}
 
 /**
  * Return WordPress subdirectory if applicable


### PR DESCRIPTION
Just a small annoyance, but here's a pull request.

Thanks,
Tom
