### PR TITLE
Added 5G Blacklist to .htaccess

### DIFF
--- a/lib/h5bp-htaccess
+++ b/lib/h5bp-htaccess
@@ -418,3 +418,73 @@ AddCharset utf-8 .atom .css .js .json .rss .vtt .xml
 <IfModule mod_php5.c>
   php_value session.cookie_httponly true
 </IfModule>
+
+# ----------------------------------------------------------------------
+# Even more security (courtesy of 5G Blacklist) see here: http://perishablepress.com/5g-blacklist-2013/
+# ----------------------------------------------------------------------
+
+# Query Strings
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteBase /
+  RewriteCond %{QUERY_STRING} (\"|%22).*(<|>|%3) [NC,OR]
+  RewriteCond %{QUERY_STRING} (javascript:).*(\;) [NC,OR]
+  RewriteCond %{QUERY_STRING} (<|%3C).*script.*(>|%3) [NC,OR]
+  RewriteCond %{QUERY_STRING} (\\|\.\./|`|=\'$|=%27$) [NC,OR]
+  RewriteCond %{QUERY_STRING} (\;|\'|\"|%22).*(union|select|insert|drop|update|md5|benchmark|or|and|if) [NC,OR]
+  RewriteCond %{QUERY_STRING} (base64_encode|localhost|mosconfig) [NC,OR]
+  RewriteCond %{QUERY_STRING} (boot\.ini|echo.*kae|etc/passwd) [NC,OR]
+  RewriteCond %{QUERY_STRING} (GLOBALS|REQUEST)(=|\[|%) [NC]
+  RewriteRule .* - [F]
+</IfModule>
+
+# User Agents
+<IfModule mod_setenvif.c>
+  # SetEnvIfNoCase User-Agent ^$ keep_out
+  SetEnvIfNoCase User-Agent (binlar|casper|cmsworldmap|comodo|diavol|dotbot|feedfinder|flicky|ia_archiver|jakarta|kmccrew|nutch|planetwork|purebot|pycurl|skygrid|sucker|turnit|vikspider|zmeu) keep_out
+  <limit GET POST PUT>
+    Order Allow,Deny
+    Allow from all
+    Deny from env=keep_out
+  </limit>
+</IfModule>
+
+# Request Strings
+<IfModule mod_alias.c>
+  RedirectMatch 403 (https?|ftp|php)\://
+  RedirectMatch 403 /(https?|ima|ucp)/
+  RedirectMatch 403 /(Permanent|Better)$
+  RedirectMatch 403 (\=\\\'|\=\\%27|/\\\'/?|\)\.css\()$
+  RedirectMatch 403 (\,|\)\+|/\,/|\{0\}|\(/\(|\.\.\.|\+\+\+|\||\\\"\\\")
+  RedirectMatch 403 \.(cgi|asp|aspx|cfg|dll|exe|jsp|mdb|sql|ini|rar)$
+  RedirectMatch 403 /(contac|fpw|install|pingserver|register)\.php$
+  RedirectMatch 403 (base64|crossdomain|localhost|wwwroot|e107\_)
+  RedirectMatch 403 (eval\(|\_vti\_|\(null\)|echo.*kae|config\.xml)
+  RedirectMatch 403 \.well\-known/host\-meta
+  RedirectMatch 403 /function\.array\-rand
+  RedirectMatch 403 \)\;\$\(this\)\.html\(
+  RedirectMatch 403 proc/self/environ
+  RedirectMatch 403 msnbot\.htm\)\.\_
+  RedirectMatch 403 /ref\.outcontrol
+  RedirectMatch 403 com\_cropimage
+  RedirectMatch 403 indonesia\.htm
+  RedirectMatch 403 \{\$itemURL\}
+  RedirectMatch 403 function\(\)
+  RedirectMatch 403 labels\.rdf
+  RedirectMatch 403 /playing.php
+  RedirectMatch 403 muieblackcat
+</IfModule>
+
+# Request Method
+<ifModule mod_rewrite.c>
+  RewriteCond %{REQUEST_METHOD} ^(TRACE|TRACK)
+  RewriteRule .* - [F]
+</IfModule>
+
+# Block Bad IPs
+<limit GET POST PUT>
+  Order Allow,Deny
+  Allow from all
+  # uncomment/edit/repeat next line to block IPs
+  # Deny from 123.456.789
+</limit>


### PR DESCRIPTION
The 5G Blacklist is a simple, flexible blacklist that checks all URI requests against a series of carefully constructed HTAccess directives. This happens quietly behind the scenes at the server level, saving resources for stuff like PHP and MySQL for all blocked requests.

Note: in some cases it may be necessary to place the QUERY STRING rules before WP-permalink rules.
