### PR TITLE
Use the new Google Analytics tracking code (Universal Analytics)

### DIFF
--- a/lib/scripts.php
+++ b/lib/scripts.php
@@ -65,12 +65,14 @@ function roots_jquery_local_fallback($src, $handle) {
 
 function roots_google_analytics() { ?>
 <script>
-  var _gaq=[['_setAccount','<?php echo GOOGLE_ANALYTICS_ID; ?>'],['_trackPageview']];
-  (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-    g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
-    s.parentNode.insertBefore(g,s)}(document,'script'));
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  ga('create', '<?php echo GOOGLE_ANALYTICS_ID; ?>');
+  ga('send', 'pageview');
 </script>
 <?php }
 if (GOOGLE_ANALYTICS_ID) {
-  add_action('wp_footer', 'roots_google_analytics', 20);
+  add_action('wp_head', 'roots_google_analytics', 20);
 }


### PR DESCRIPTION
Google recently deployed their new tracking code as a public beta, and [recommend new installations use this](https://developers.google.com/analytics/devguides/collection/analyticsjs/):

> The analytics.js snippet is part of Universal Analytics, which is currently in public beta. New users should use analytics.js. […] To begin tracking a website using analytics.js, paste the following JavaScript snippet into your website template page so that it appears before the closing </head> tag.

I've updated `lib/scripts.php` to
1. Use this new script, and
2. Output to `wp_head()` instead of `wp_footer()` as suggested by Google.

I should state up front that I only have basic experience with the new tracking code. I just figured that Roots developers might benefit from the added flexibility, and that Roots itself should be up to date with any vendored plugins/scripts.

What's your opinion?  
