### PR TITLE
Never remove media attribute on link tags

### DIFF
--- a/lib/cleanup.php
+++ b/lib/cleanup.php
@@ -95,6 +95,17 @@ function roots_wp_title($title) {
 add_filter('wp_title', 'roots_wp_title', 10);
 
 /**
+ * Clean up output of stylesheet <link> tags
+ */
+function roots_clean_style_tag($input) {
+  preg_match_all("!<link rel='stylesheet'\s?(id='[^']+')?\s+href='(.*)' type='text/css' media='(.*)' />!", $input, $matches);
+  // Only display media if it is meaningful
+  $media = $matches[3][0] !== '' && $matches[3][0] !== 'all' ? ' media="' . $matches[3][0] . '"' : '';
+  return '<link rel="stylesheet" href="' . $matches[2][0] . '"' . $media . '>' . "\n";
+}
+add_filter('style_loader_tag', 'roots_clean_style_tag');
+
+/**
  * Add and remove body_class() classes
  */
 function roots_body_class($classes) {


### PR DESCRIPTION
You don't provide rationals why you decided to remove the media attribute of link tags unless their value is 'print'.
The media attribute can be used for much more than providing print style, I use it for media queries to achieve responsive designs (view source on http://lagammebeaujolaise.com ).

I suggest not cleaning up style tags at all, this isn't worth the trouble.
