### PR TITLE
Rework Roots_Wrapping class

### DIFF
--- a/lib/wrapper.php
+++ b/lib/wrapper.php
@@ -9,7 +9,7 @@ function roots_template_path() {
 }
 
 function roots_sidebar_path() {
-  return Roots_Wrapping::sidebar();
+  return Roots_Wrapping('templates/sidebar.php');
 }
 
 class Roots_Wrapping {
@@ -19,34 +19,30 @@ class Roots_Wrapping {
   // Stores the base name of the template file; e.g. 'page' for 'page.php' etc.
   static $base;
 
-  static function wrap($template) {
-    self::$main_template = $template;
-
-    self::$base = substr(basename(self::$main_template), 0, -4);
+  public function __construct($template='base.php') {
+    $this->slug = basename($template, '.php');
+    $this->templates = array($template);
+    
+    if (self::$base) {
+      $str = substr($template, 0, -4);
+      array_unshift($this->templates, sprintf($str . '-%s.php', self::$base));
+    }
+  }
+  
+  public function __toString() {
+    $this->templates = apply_filters('roots_wrap_' . $this->slug, $this->templates);
+    return locate_template($this->templates);
+  }
+  
+  static function wrap($main) {
+    self::$main_template = $main;
+    self::$base = basename(self::$main_template, '.php');
 
     if (self::$base === 'index') {
       self::$base = false;
     }
-
-    $templates = array('base.php');
-
-    if (self::$base) {
-      array_unshift($templates, sprintf('base-%s.php', self::$base));
-    }
-
-    $templates = apply_filters('roots_wrap_base', $templates);
-    return locate_template($templates);
-  }
-
-  static function sidebar() {
-    $templates = array('templates/sidebar.php');
-
-    if (self::$base) {
-      array_unshift($templates, sprintf('templates/sidebar-%s.php', self::$base));
-    }
-
-    $templates = apply_filters('roots_wrap_sidebar', $templates);
-    return locate_template($templates);
+    
+    return new Roots_Wrapping();
   }
 }
 add_filter('template_include', array('Roots_Wrapping', 'wrap'), 99);


### PR DESCRIPTION
Apply the wrapper to any template by creating a new instance.
To use this in a theme either create a new function to wrap the object:

``` php
<?php 
function roots_file_path() {
  return Roots_Wrapping('path/to/template/file.php');
}
?>
```

Then include the function:

``` php
<?php include roots_file_path; ?>
```

Or just include the new object directly;

``` php
<?php include new Roots_Wrapping('path/to/template/file.php'); ?>
```

Or create a new variable for the object include that;

``` php
<?php 
$file_wrapper = new Roots_Wrapping('path/to/template/file.php');
include $file_wrapper; 
?>
```
