### PR TITLE
Update scripts.php to use current jQuery version

### DIFF
--- a/lib/scripts.php
+++ b/lib/scripts.php
@@ -22,9 +22,11 @@ function roots_scripts() {
   // Grab Google CDN's latest jQuery with a protocol relative URL; fallback to local if offline
   // It's kept in the header instead of footer to avoid conflicts with plugins.
   if (!is_admin() && current_theme_supports('jquery-cdn')) {
-    $cur_jquery_ver = roots_get_jquery_version();
+    if ( ! array_key_exists('cur_jquery_ver', $GLOBALS) ) {
+      $GLOBALS['cur_jquery_ver'] = roots_get_jquery_version();
+    }
     wp_deregister_script('jquery');
-    wp_register_script('jquery', '//ajax.googleapis.com/ajax/libs/jquery/' . $cur_jquery_ver . '/jquery.min.js', false, null, false);
+    wp_register_script('jquery', '//ajax.googleapis.com/ajax/libs/jquery/' . $GLOBALS['cur_jquery_ver'] . '/jquery.min.js', false, null, false);
     add_filter('script_loader_src', 'roots_jquery_local_fallback', 10, 2);
   }
 
@@ -47,7 +49,7 @@ function roots_jquery_local_fallback($src, $handle) {
   static $add_jquery_fallback = false;
 
   if ($add_jquery_fallback) {
-    echo '<script>window.jQuery || document.write(\'<script src="' . get_template_directory_uri() . '/assets/js/vendor/jquery-' . roots_get_jquery_version() . '.min.js"><\/script>\')</script>' . "\n";
+    echo '<script>window.jQuery || document.write(\'<script src="' . get_template_directory_uri() . '/assets/js/vendor/jquery-' . $GLOBALS['cur_jquery_ver'] . '.min.js"><\/script>\')</script>' . "\n";
     $add_jquery_fallback = false;
   }
 


### PR DESCRIPTION
This updates the CDN version to always use the jQuery version that is bundled in the currently installed WordPress version.  Including a newer version than what is bundled may cause issues with plugins that aren't expecting it.
