### PR TITLE
force figure elements to max-width of 100%

### DIFF
--- a/lib/cleanup.php
+++ b/lib/cleanup.php
@@ -163,7 +163,7 @@ function roots_caption($output, $attr, $content) {
   // Set up the attributes for the caption <figure>
   $attributes  = (!empty($attr['id']) ? ' id="' . esc_attr($attr['id']) . '"' : '' );
   $attributes .= ' class="thumbnail wp-caption ' . esc_attr($attr['align']) . '"';
-  $attributes .= ' style="width: ' . esc_attr($attr['width']) . 'px"';
+  $attributes .= ' style="width: ' . esc_attr($attr['width']) . 'px; max-width: 100%;"';
 
   $output  = '<figure' . $attributes .'>';
   $output .= do_shortcode($content);


### PR DESCRIPTION
because the width is declared inline, `<figure>` will break responsive layouts if it exceeds the width of its parent on small screens. by declaring `max-width: 100%;` inline instead of in a stylesheet, layouts will no longer break.

the alternative would be to remove width altogether.
