### PR TITLE
Allow nav depth override

### DIFF
--- a/lib/nav.php
+++ b/lib/nav.php
@@ -80,7 +80,7 @@ function roots_nav_menu_args($args = '') {
     $roots_nav_menu_args['items_wrap'] = '<ul class="%2$s">%3$s</ul>';
   }
 
-  if (current_theme_supports('bootstrap-top-navbar')) {
+  if (current_theme_supports('bootstrap-top-navbar') && !$args['depth']) {
     $roots_nav_menu_args['depth'] = 2;
   }
 


### PR DESCRIPTION
Allows a manually stated menu depth to override the default. Per #834.
