### PR TITLE
Update functions.php - replacing redundant require_once

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2,19 +2,19 @@
 /**
  * Roots includes
  */
-require_once locate_template('/lib/utils.php');           // Utility functions
-require_once locate_template('/lib/init.php');            // Initial theme setup and constants
-require_once locate_template('/lib/wrapper.php');         // Theme wrapper class
-require_once locate_template('/lib/sidebar.php');         // Sidebar class
-require_once locate_template('/lib/config.php');          // Configuration
-require_once locate_template('/lib/activation.php');      // Theme activation
-require_once locate_template('/lib/titles.php');          // Page titles
-require_once locate_template('/lib/cleanup.php');         // Cleanup
-require_once locate_template('/lib/nav.php');             // Custom nav modifications
-require_once locate_template('/lib/gallery.php');         // Custom [gallery] modifications
-require_once locate_template('/lib/comments.php');        // Custom comments modifications
-require_once locate_template('/lib/rewrites.php');        // URL rewriting for assets
-require_once locate_template('/lib/relative-urls.php');   // Root relative URLs
-require_once locate_template('/lib/widgets.php');         // Sidebars and widgets
-require_once locate_template('/lib/scripts.php');         // Scripts and stylesheets
-require_once locate_template('/lib/custom.php');          // Custom functions
+locate_template('/lib/utils.php', true);           // Utility functions
+locate_template('/lib/init.php', true);            // Initial theme setup and constants
+locate_template('/lib/wrapper.php', true);         // Theme wrapper class
+locate_template('/lib/sidebar.php', true);         // Sidebar class
+locate_template('/lib/config.php', true);          // Configuration
+locate_template('/lib/activation.php', true);      // Theme activation
+locate_template('/lib/titles.php', true);          // Page titles
+locate_template('/lib/cleanup.php', true);         // Cleanup
+locate_template('/lib/nav.php', true);             // Custom nav modifications
+locate_template('/lib/gallery.php', true);         // Custom [gallery] modifications
+locate_template('/lib/comments.php', true);        // Custom comments modifications
+locate_template('/lib/rewrites.php', true);        // URL rewriting for assets
+locate_template('/lib/relative-urls.php', true);   // Root relative URLs
+locate_template('/lib/widgets.php', true);         // Sidebars and widgets
+locate_template('/lib/scripts.php', true);         // Scripts and stylesheets
+locate_template('/lib/custom.php', true);          // Custom functions


### PR DESCRIPTION
http://codex.wordpress.org/Function_Reference/locate_template

<?php locate_template( $template_names, $load, $require_once ) ?>

By setting the second parameter to true, we load the file. The third parameter of 'require once' defaults to true anyway so it automatically requires the file.

Hope that's useful.
