### PR TITLE
Sidebar support for args array

### DIFF
--- a/lib/sidebar.php
+++ b/lib/sidebar.php
@@ -30,7 +30,7 @@ class Roots_Sidebar {
 
   private function check_conditional_tag($conditional_tag) {
     if (is_array($conditional_tag)) {
-      return call_user_func_array($conditional_tag[0], $conditional_tag[1]);
+      return $conditional_tag[0]($conditional_tag[1]);
     } else {
       return $conditional_tag();
     }


### PR DESCRIPTION
Using `call_user_func_array` processes the arguments one at a time using callbacks, so only the first result is returned. Most conditional tags support passing an array as the argument so we may as well just pass the whole thing in one go.

This will enable the `Sidebar_Class` to process more complicated checks such as the final example below:

``` php
array(
  'is_404',
  'is_front_page',
  array('is_page', array(42, 'page-slug', 'Page Title'))
),
```
