### PR TITLE
Add support for multilevel dropdown menus

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -74,6 +74,20 @@ figure.alignnone { margin-left: 0; margin-right: 0; }
 
 
 /* ==========================================================================
+   Add support for multilevel dropdown menus
+   See: http://bootply.com/74918
+   ========================================================================== */
+
+.dropdown-submenu{position:relative;}
+.dropdown-submenu>.dropdown-menu{top:0;left:100%;margin-top:-6px;margin-left:-1px;-webkit-border-radius:0 6px 6px 6px;-moz-border-radius:0 6px 6px 6px;border-radius:0 6px 6px 6px;}
+.dropdown-submenu:hover>.dropdown-menu{display:block;}
+.dropdown-submenu>a:after{display:block;content:" ";float:right;width:0;height:0;border-color:transparent;border-style:solid;border-width:5px 0 5px 5px;border-left-color:#cccccc;margin-top:5px;margin-right:-10px;}
+.dropdown-submenu:hover>a:after{border-left-color:#ffffff;}
+.dropdown-submenu.pull-left{float:none;}.dropdown-submenu.pull-left>.dropdown-menu{left:-100%;margin-left:10px;-webkit-border-radius:6px 0 6px 6px;-moz-border-radius:6px 0 6px 6px;border-radius:6px 0 6px 6px;}
+
+
+
+/* ==========================================================================
    Media Queries
    ========================================================================== */
 

--- a/lib/nav.php
+++ b/lib/nav.php
@@ -42,7 +42,12 @@ class Roots_Nav_Walker extends Walker_Nav_Menu {
     $element->is_dropdown = ((!empty($children_elements[$element->ID]) && (($depth + 1) < $max_depth || ($max_depth === 0))));
 
     if ($element->is_dropdown) {
-      $element->classes[] = 'dropdown';
+        if($depth > 0) {
+            $element->classes[] = 'dropdown-submenu';
+        }
+        else {
+            $element->classes[] = 'dropdown';
+        }
     }
 
     parent::display_element($element, $children_elements, $max_depth, $depth, $args, $output);


### PR DESCRIPTION
Due to multilevel menus has been dropped in Bootstrap 3, some code
changes are neccessary to get this function back. Imho this feature is needed because a lot of pages use menus that are deeper than 2 levels.
