### PR TITLE
Fixed error with jshint's ES5 option

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,7 +4,6 @@
   "curly": true,
   "eqeqeq": true,
   "eqnull": true,
-  "es5": true,
   "esnext": true,
   "immed": true,
   "jquery": true,


### PR DESCRIPTION
It should solve this: http://discourse.roots.io/t/grunt-error-on--main-js/159
