### PR TITLE
Added browser live reloading to Grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,7 +70,9 @@ module.exports = function(grunt) {
         },
         files: [
           'assets/css/main.min.css',
-          'assets/js/scripts.min.js'
+          'assets/js/scripts.min.js',
+          'templates/*.php',
+          '*.php'
         ]
       }
     },


### PR DESCRIPTION
This comes with the latest version of [grunt's watch task](https://github.com/gruntjs/grunt-contrib-watch#live-reloading) (which is already referenced in package.json) and is pretty easy and straightforward to use. It only requires the [livereload browser plugin](https://github.com/gruntjs/grunt-contrib-watch#using-live-reload-with-the-browser-extension) or [adding a <script> tag](https://github.com/gruntjs/grunt-contrib-watch#enabling-live-reload-in-your-html). 

Also, I made it optional and disabled by default.
