### PR TITLE
Hide Google Analytics to admins to prevent obscured data.

### DIFF
--- a/lib/scripts.php
+++ b/lib/scripts.php
@@ -61,6 +61,6 @@ function roots_google_analytics() { ?>
 </script>
 
 <?php }
-if (GOOGLE_ANALYTICS_ID) {
+if (GOOGLE_ANALYTICS_ID && !current_user_can('manage_options')) {
   add_action('wp_footer', 'roots_google_analytics', 20);
 }


### PR DESCRIPTION
When working on the site in staging whenever I test websites I am adding hits to Google analytics and really affects time on site and bounce rate. It will only hide for Administrators but could be hidden depending on the capabilities here: http://codex.wordpress.org/Roles_and_Capabilities#Capability_vs._Role_Table
