### PR TITLE
Comment config.php excerpt length is in words

### DIFF
--- a/lib/config.php
+++ b/lib/config.php
@@ -13,7 +13,7 @@ add_theme_support('jquery-cdn');            // Enable to load jQuery from the Go
  * Configuration values
  */
 define('GOOGLE_ANALYTICS_ID', ''); // UA-XXXXX-Y
-define('POST_EXCERPT_LENGTH', 40); // words
+define('POST_EXCERPT_LENGTH', 40); // length in words for excerpt_length filter (ref: http://codex.wordpress.org/Plugin_API/Filter_Reference/excerpt_length)
 
 /**
  * .main classes


### PR DESCRIPTION
Add comment to POST_EXCERPT_LENGTH to indicate it is in words, not characters.

(Hope I'm doing this right. Still learning how to git/hub.)
