### PR TITLE
Change IE conditional statement so alert appears on IE7

### DIFF
--- a/base.php
+++ b/base.php
@@ -1,7 +1,7 @@
 <?php get_template_part('templates/head'); ?>
 <body <?php body_class(); ?>>
 
-  <!--[if lt IE 7]><div class="alert alert-warning"><?php _e('You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.', 'roots'); ?></div><![endif]-->
+  <!--[if lt IE 8]><div class="alert alert-warning"><?php _e('You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.', 'roots'); ?></div><![endif]-->
 
   <?php
     do_action('get_header');


### PR DESCRIPTION
Bootstrap 3 no longer supports IE7. The roots outdated browser warning should now appear on anything earlier than IE8.
