### PR TITLE
Predefine Modernizr object to avoid JSHint errors

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -13,5 +13,6 @@
   "node": true,
   "strict": false,
   "trailing": true,
-  "undef": true
+  "undef": true,
+  "predef" : ["Modernizr"]
 }


### PR DESCRIPTION
Added `Modernizr` to the list of JSHint predefined functions to avoid warnings when using `grunt jshint` if `_main.js` have any reference to Modernizr object (e.g., feature detection functions).
