### PR TITLE
Add 10 px to the width of <figure> to avoid figure overflow

### DIFF
--- a/lib/cleanup.php
+++ b/lib/cleanup.php
@@ -163,7 +163,7 @@ function roots_caption($output, $attr, $content) {
   // Set up the attributes for the caption <figure>
   $attributes  = (!empty($attr['id']) ? ' id="' . esc_attr($attr['id']) . '"' : '' );
   $attributes .= ' class="thumbnail wp-caption ' . esc_attr($attr['align']) . '"';
-  $attributes .= ' style="width: ' . esc_attr($attr['width']) . 'px"';
+  $attributes .= ' style="width: ' . (esc_attr($attr['width']) + 10) . 'px"';
 
   $output  = '<figure' . $attributes .'>';
   $output .= do_shortcode($content);


### PR DESCRIPTION
Sorry for the pull request with two changes (a little  new to GitHub's pull request thingy).

Now with only one ...

There may be other ways to do this - but the "out of the box" figures looks crap - as the width is set to EXACTLY the width of the image.
