### PR TITLE
When "Link to" is set to "None" in Gallery Settings, display the image without a link.

### DIFF
--- a/lib/gallery.php
+++ b/lib/gallery.php
@@ -85,7 +85,7 @@ function roots_gallery($attr) {
 
   $i = 0;
   foreach ($attachments as $id => $attachment) {
-    $image = ('file' == $link) ? wp_get_attachment_link($id, $size, false, false) : wp_get_attachment_link($id, $size, true, false);
+    $image = ('file' == $link) ? wp_get_attachment_link($id, $size, false, false) : wp_get_attachment_image($id, $size, false);
     $output .= ($i % $columns == 0) ? '<div class="row gallery-row">': '';
     $output .= '<div class="' . $grid .'">' . $image;
 


### PR DESCRIPTION
BUGFIX: at the moment, gallery images are always displayed with links. (it looks like wp_get_attachment_link() was accidentally used instead of wp_get_attachment_image()).
