### PR TITLE
Fix gallery link option

### DIFF
--- a/lib/gallery.php
+++ b/lib/gallery.php
@@ -44,7 +44,7 @@ function roots_gallery($attr) {
     'size'       => 'thumbnail',
     'include'    => '',
     'exclude'    => '',
-    'link'       => 'file'
+    'link'       => ''
   ), $attr));
 
   $id = intval($id);
@@ -85,7 +85,17 @@ function roots_gallery($attr) {
 
   $i = 0;
   foreach ($attachments as $id => $attachment) {
-    $image = ('file' == $link) ? wp_get_attachment_link($id, $size, false, false) : wp_get_attachment_link($id, $size, true, false);
+    switch($link) {
+      case 'file':
+        $image = wp_get_attachment_link($id, $size, false, false);
+        break;
+      case 'none':
+        $image = wp_get_attachment_image($id, $size, false, array('class' => 'thumbnail img-thumbnail'));
+        break;
+      default:
+        $image = wp_get_attachment_link($id, $size, true, false);
+        break;
+    }
     $output .= ($i % $columns == 0) ? '<div class="row gallery-row">': '';
     $output .= '<div class="' . $grid .'">' . $image;
 


### PR DESCRIPTION
```
Galleries should support three link types:

* Attachment Page (default): [gallery ids="1,2,3"]
* Media File: [gallery link="file" ids="1,2,3"]
* None: [gallery link="none" ids="1,2,3"]
```

Only thing I'm not sure about are the classes @ [[L93:C80]](https://github.com/leoj3n/roots/blob/261fb43776d8bdad7275d2e23d0e55e49cba2109/lib/gallery.php#L93)
