### PR TITLE
add "updated" to hNews microformat to support Google structured data

### DIFF
--- a/templates/entry-meta.php
+++ b/templates/entry-meta.php
@@ -1,2 +1,2 @@
-<time class="published" datetime="<?php echo get_the_time('c'); ?>"><?php echo get_the_date(); ?></time>
+<time class="published updated" datetime="<?php echo get_the_time('c'); ?>"><?php echo get_the_date(); ?></time>
 <p class="byline author vcard"><?php echo __('By', 'roots'); ?> <a href="<?php echo get_author_posts_url(get_the_author_meta('ID')); ?>" rel="author" class="fn"><?php echo get_the_author(); ?></a></p>


### PR DESCRIPTION
Google's structured data testing tool requires that hentry items are
tagged with an "updated time". This fix will remove the "missing
required field updated" error in Webmaster Tools and the Structured Data
Testing Tool
