### PR TITLE
Gruntfile update - separates out tasks and options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,123 +1,52 @@
+/*
+
+This Gruntfile will find and read tasks in the /tasks directory
+and all task options in /tasks/options.
+
+To add new commands to the default build task save its options to 
+/task/options and add a reference to the task as an option in 
+grunt.registerTask('default') at the bottom of this file.
+
+If you're deep in terminal and forget them, run `grunt --help` to list
+all available tasks.
+
+*/
 'use strict';
 module.exports = function(grunt) {
 
-  grunt.initConfig({
-    jshint: {
-      options: {
-        jshintrc: '.jshintrc'
-      },
-      all: [
-        'Gruntfile.js',
-        'assets/js/*.js',
-        '!assets/js/scripts.min.js'
-      ]
-    },
-    less: {
-      dist: {
-        files: {
-          'assets/css/main.min.css': [
-            'assets/less/app.less'
-          ]
-        },
-        options: {
-          compress: true,
-          // LESS source map
-          // To enable, set sourceMap to true and update sourceMapRootpath based on your install
-          sourceMap: false,
-          sourceMapFilename: 'assets/css/main.min.css.map',
-          sourceMapRootpath: '/app/themes/roots/'
-        }
-      }
-    },
-    uglify: {
-      dist: {
-        files: {
-          'assets/js/scripts.min.js': [
-            'assets/js/plugins/bootstrap/transition.js',
-            'assets/js/plugins/bootstrap/alert.js',
-            'assets/js/plugins/bootstrap/button.js',
-            'assets/js/plugins/bootstrap/carousel.js',
-            'assets/js/plugins/bootstrap/collapse.js',
-            'assets/js/plugins/bootstrap/dropdown.js',
-            'assets/js/plugins/bootstrap/modal.js',
-            'assets/js/plugins/bootstrap/tooltip.js',
-            'assets/js/plugins/bootstrap/popover.js',
-            'assets/js/plugins/bootstrap/scrollspy.js',
-            'assets/js/plugins/bootstrap/tab.js',
-            'assets/js/plugins/bootstrap/affix.js',
-            'assets/js/plugins/*.js',
-            'assets/js/_*.js'
-          ]
-        },
-        options: {
-          // JS source map: to enable, uncomment the lines below and update sourceMappingURL based on your install
-          // sourceMap: 'assets/js/scripts.min.js.map',
-          // sourceMappingURL: '/app/themes/roots/assets/js/scripts.min.js.map'
-        }
-      }
-    },
-    version: {
-      options: {
-        file: 'lib/scripts.php',
-        css: 'assets/css/main.min.css',
-        cssHandle: 'roots_main',
-        js: 'assets/js/scripts.min.js',
-        jsHandle: 'roots_scripts'
-      }
-    },
-    watch: {
-      less: {
-        files: [
-          'assets/less/*.less',
-          'assets/less/bootstrap/*.less'
-        ],
-        tasks: ['less', 'version']
-      },
-      js: {
-        files: [
-          '<%= jshint.all %>'
-        ],
-        tasks: ['jshint', 'uglify', 'version']
-      },
-      livereload: {
-        // Browser live reloading
-        // https://github.com/gruntjs/grunt-contrib-watch#live-reloading
-        options: {
-          livereload: false
-        },
-        files: [
-          'assets/css/main.min.css',
-          'assets/js/scripts.min.js',
-          'templates/*.php',
-          '*.php'
-        ]
-      }
-    },
-    clean: {
-      dist: [
-        'assets/css/main.min.css',
-        'assets/js/scripts.min.js'
-      ]
-    }
-  });
+  // Utility to load the different option files
+  // based on their names
+  function loadConfig(path) {
+    var glob = require('glob');
+    var object = {};
+    var key;
 
-  // Load tasks
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-contrib-less');
-  grunt.loadNpmTasks('grunt-wp-version');
+    glob.sync('*', {cwd: path}).forEach(function(option) {
+      key = option.replace(/\.js$/,'');
+      object[key] = require(path + option);
+    });
 
-  // Register tasks
-  grunt.registerTask('default', [
-    'clean',
-    'less',
-    'uglify',
-    'version'
-  ]);
-  grunt.registerTask('dev', [
-    'watch'
-  ]);
+    return object;
+  }
+
+  // Initial config
+  var config = {
+    pkg: grunt.file.readJSON('package.json')
+  };
+
+  // Load tasks from the tasks folder
+  grunt.loadTasks('tasks');
+
+  // Load all the tasks options in tasks/options base on the name:
+  // watch.js => watch{}
+  grunt.util._.extend(config, loadConfig('./tasks/options/'));
+
+  grunt.initConfig(config);
+
+  require('load-grunt-tasks')(grunt);
+
+  // Default Task is build
+  // Find the options for these tasks in /tasks/options
+  grunt.registerTask('default', ['clean', 'concat', 'uglify', 'less', 'cssmin', 'version']);
 
 };

--- a/package.json
+++ b/package.json
@@ -19,11 +19,17 @@
   },
   "devDependencies": {
     "grunt": "~0.4.2",
+    "glob": "~3.2.8",
     "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-jshint": "~0.6.4",
+    "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-cssmin": "~0.7.0",
+    "grunt-contrib-jshint": "~0.7.2",
+    "grunt-contrib-less": "~0.8.1",
     "grunt-contrib-uglify": "~0.2.4",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-contrib-less": "~0.8.1",
     "grunt-wp-version": "~0.1.0"
+  },
+  "dependencies": {
+    "load-grunt-tasks": "~0.2.0"
   }
 }

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -1,0 +1,4 @@
+// build.js gives you a `grunt build` task, it's the same as the default task but its command is a bit simpler to remember
+module.exports = function(grunt) {
+  grunt.registerTask('build', ['clean', 'concat', 'uglify', 'less', 'cssmin', 'version']);
+};

--- a/tasks/custom.js
+++ b/tasks/custom.js
@@ -1,0 +1,6 @@
+// custom.js is a template for you to create your own tasks
+module.exports = function(grunt) {
+  grunt.registerTask('custom', 'Say hello!', function() {
+    grunt.log.writeln("Custom task log");
+  });
+};

--- a/tasks/dev.js
+++ b/tasks/dev.js
@@ -1,0 +1,4 @@
+// dev.js gives you a `grunt dev` task, which builds and then watches for changes
+module.exports = function(grunt) {
+  grunt.registerTask('dev', ['clean', 'concat', 'uglify', 'less', 'cssmin', 'version', 'watch']);
+};

--- a/tasks/options/clean.js
+++ b/tasks/options/clean.js
@@ -1,0 +1,7 @@
+// clean.js cleans your minified files to force a new write each time
+module.exports = {
+  dist: [
+    'assets/css/main.min.css',
+    'assets/js/scripts.min.js'
+  ]
+}

--- a/tasks/options/concat.js
+++ b/tasks/options/concat.js
@@ -1,0 +1,22 @@
+// concat.js combines scripts into one file but does not minify, uglify.js does that
+module.exports = {
+  dist: {
+    src: [
+      	'assets/js/plugins/bootstrap/transition.js',
+	    'assets/js/plugins/bootstrap/alert.js',
+	    'assets/js/plugins/bootstrap/button.js',
+	    'assets/js/plugins/bootstrap/carousel.js',
+	    'assets/js/plugins/bootstrap/collapse.js',
+	    'assets/js/plugins/bootstrap/dropdown.js',
+	    'assets/js/plugins/bootstrap/modal.js',
+	    'assets/js/plugins/bootstrap/tooltip.js',
+	    'assets/js/plugins/bootstrap/popover.js',
+	    'assets/js/plugins/bootstrap/scrollspy.js',
+	    'assets/js/plugins/bootstrap/tab.js',
+	    'assets/js/plugins/bootstrap/affix.js',
+	    'assets/js/plugins/*.js',
+	    'assets/js/_*.js'
+    ],
+    dest: 'assets/js/scripts.js'
+  }
+}

--- a/tasks/options/cssmin.js
+++ b/tasks/options/cssmin.js
@@ -1,0 +1,8 @@
+// cssmin.js minifies the css
+module.exports = {
+  combine: {
+    files: {
+      'assets/css/main.min.css': ['assets/css/main.css']
+    }
+  }
+}

--- a/tasks/options/jshint.js
+++ b/tasks/options/jshint.js
@@ -1,0 +1,11 @@
+// jshint.js
+module.exports = {
+  options: {
+    jshintrc: '.jshintrc'
+  },
+  beforeconcat: [
+  	'Gruntfile.js',
+  	'assets/js/*.js',
+  	'!assets/js/scripts.min.js'
+  ]
+}

--- a/tasks/options/less.js
+++ b/tasks/options/less.js
@@ -1,0 +1,17 @@
+// less.js runs LESS for you
+module.exports = {
+  dist: {
+    options: {
+      // cssmin will minify later
+      compress: false,
+      // LESS source map
+      // To enable, set sourceMap to true and update sourceMapRootpath based on your install
+      sourceMap: false,
+      sourceMapFilename: 'assets/css/main.min.css.map',
+      sourceMapRootpath: '/app/themes/roots/'
+    },
+    files: {
+      'assets/css/main.css': 'assets/less/app.less'
+    },
+  }
+}

--- a/tasks/options/uglify.js
+++ b/tasks/options/uglify.js
@@ -1,0 +1,12 @@
+// uglify.js minifies the js after it's been combined by concat.js
+module.exports = {
+  build: {
+    src: 'assets/js/scripts.js',
+    dest: 'assets/js/scripts.min.js',
+    options: {
+      // JS source map: to enable, uncomment the lines below and update sourceMappingURL based on your install
+      // sourceMap: 'assets/js/scripts.min.js.map',
+      // sourceMappingURL: '/app/themes/roots/assets/js/scripts.min.js.map'    	
+    }
+  }
+}

--- a/tasks/options/version.js
+++ b/tasks/options/version.js
@@ -1,0 +1,10 @@
+// version.js updates the version for css + js in lib/scripts.php to cache-bust
+module.exports = {
+  options: {
+    file: 'lib/scripts.php',
+    css: 'assets/css/main.min.css',
+	cssHandle: 'roots_main',
+	js: 'assets/js/scripts.min.js',
+	jsHandle: 'roots_scripts'
+  }
+}

--- a/tasks/options/watch.js
+++ b/tasks/options/watch.js
@@ -1,0 +1,48 @@
+// watch.js watches files to run tasks and run livereload
+module.exports = {
+  options: {
+    // Browser live reloading
+    // https://github.com/gruntjs/grunt-contrib-watch#live-reloading
+    livereload: true,
+  },
+  scripts: {
+    files: [
+      'Gruntfile.js',
+      'assets/js/*.js',
+      '!assets/js/scripts.min.js'
+    ],
+    tasks: ['jshint', 'concat', 'uglify', 'version'],
+    options: {
+      spawn: false,
+    }
+  },
+  css: {
+    files: ['assets/css/*.css'],
+    tasks: [],
+    options: {
+      nospawn: false
+    }
+  },
+  less: {
+    options: {
+      nospawn: false,
+      livereload: false
+    },
+    files: [
+      'assets/less/*.less',
+      'assets/less/bootstrap/*.less'
+      ],
+    tasks: ['less', 'cssmin', 'version']
+  },
+  php:{
+    files: [
+      'templates/*.php',
+      'lib/*.php',
+      '*.php'
+    ],
+    tasks: [],
+    options: {
+      spawn: false
+    }
+  }
+}


### PR DESCRIPTION
Hey guys,

Having looked into [Chris Coyiers' Gruntfile boilerplate](https://github.com/chriscoyier/My-Grunt-Boilerplate), I implemented it into my roots-based theme. Thought I'd send it as a PR in case you thought it would be good for Roots.

The main difference is that it separates out tasks and options. Tasks are defined as their own files in [/tasks](https://github.com/ptibbetts/roots/tree/pr-gruntfile-update/tasks) and the options for these tasks are defined in [/tasks/options](https://github.com/ptibbetts/roots/tree/pr-gruntfile-update/tasks/options).

It also:
- adds `grunt build` task (same as `grunt` task) so you can run grunt or grunt build - [/tasks/build.js](https://github.com/ptibbetts/roots/blob/pr-gruntfile-update/tasks/build.js)
- adds a custom grunt task template - [/tasks/custom.js](https://github.com/ptibbetts/roots/blob/pr-gruntfile-update/tasks/custom.js)
- changes `grunt dev` task to build then watch - [/tasks/dev.js](https://github.com/ptibbetts/roots/blob/pr-gruntfile-update/tasks/dev.js)
- turns livereload on by default - [/tasks/options/watch.js](https://github.com/ptibbetts/roots/blob/pr-gruntfile-update/tasks/options/watch.js#L6)

If you think this'd be good for Roots but want something changed or explaining just let me know. 
_If_ you were to integrate this then the [docs for the Gruntfile](http://roots.io/using-grunt-for-wordpress-theme-development/) would need updating and I'd be happy to help doing so.
