### PR TITLE
Fix for duplicate active menu items.

### DIFF
--- a/lib/nav.php
+++ b/lib/nav.php
@@ -55,14 +55,17 @@ class Roots_Nav_Walker extends Walker_Nav_Menu {
  */
 function roots_nav_menu_css_class($classes, $item) {
   $slug = sanitize_title($item->title);
-  $classes = preg_replace('/(current(-menu-|[-_]page[-_])(item|parent|ancestor))/', 'active', $classes);
-  $classes = preg_replace('/^((menu|page)[-_\w+]+)+/', '', $classes);
+  $new_classes = preg_replace('/(current(-menu-|[-_]page[-_])(item|parent|ancestor))/', 'active', $classes);
+  $new_classes = preg_replace('/^((menu|page)[-_\w+]+)+/', '', $new_classes);
 
-  $classes[] = 'menu-' . $slug;
-
-  $classes = array_unique($classes);
-
-  return array_filter($classes, 'is_element_empty');
+  $new_classes[] = 'menu-' . $slug;
+  $new_class_counts = array_count_values($new_classes);
+  $new_classes = array_unique($new_classes);
+  if($new_class_counts['active'] < 2 && array_search('current-menu-item', $classes) === false)
+  {
+    unset($new_classes[array_search('active', $new_classes)]);
+  }
+  return array_filter($new_classes, 'is_element_empty');
 }
 add_filter('nav_menu_css_class', 'roots_nav_menu_css_class', 10, 2);
 add_filter('nav_menu_item_id', '__return_null');


### PR DESCRIPTION
There's a duplication of active menu items when using custom post types. Namely that custom posts nested beneath a page cause the blog to become `.active` while simultaneously setting the parent page `.active` and the current menu item `.active`. This patch fixes all that nonsense. If you `print_r($classes); print_r($new_classes)` on line 60 you'll see that there are always at least 2 active replaces prior to the `array_unique($new_classes)`. The `array_search('current-menu-item',...` conditional check  is to ensure that `.active` is still set for current menu item regardless of the number of `$new_class_counts`.
