### PR TITLE
Suppress jquery/modernizr from scripts.min.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,6 +46,11 @@ module.exports = function(grunt) {
             'assets/js/plugins/bootstrap/tab.js',
             'assets/js/plugins/bootstrap/affix.js',
             'assets/js/plugins/*.js',
+            
+            // Ignore jquery and modernizr, they are loaded in the header
+            '!assets/js/vendor/jquery-1.*.min.js',
+            '!assets/js/vendor/modernizr-*.min.js',
+            
             'assets/js/_*.js'
           ]
         },


### PR DESCRIPTION
jquery and modernizr are already loaded in the header (via scripts.php). Compiling them into scripts.min.js is redundant, makes the file larger, and potentially causes problems (removing jquery event bindings, etc.).
