### PR TITLE
Use grunt-wp-assets for version task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 node_modules
 assets/vendor/*
 assets/css/main.min.css.map
+assets/css/*main.*.min.css
+assets/js/*scripts.*.min.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,12 +57,9 @@ module.exports = function(grunt) {
       }
     },
     version: {
-      options: {
-        file: 'lib/scripts.php',
-        css: 'assets/css/main.min.css',
-        cssHandle: 'roots_main',
-        js: 'assets/js/scripts.min.js',
-        jsHandle: 'roots_scripts'
+      assets: {
+        src: ['assets/css/main.min.css', 'assets/js/scripts.min.js'],
+        dest: 'lib/scripts.php'
       }
     },
     modernizr: {
@@ -119,7 +116,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-less');
-  grunt.loadNpmTasks('grunt-wp-version');
+  grunt.loadNpmTasks('grunt-wp-assets');
   grunt.loadNpmTasks('grunt-modernizr');
 
   // Register tasks

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt-contrib-uglify": "~0.2.4",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-less": "~0.8.1",
-    "grunt-wp-version": "~0.1.0",
+    "grunt-wp-assets": "~0.2.1",
     "grunt-modernizr": "~0.5.1"
   }
 }


### PR DESCRIPTION
- Default use filename version revving instead of querystring.
- Versioning file will be ignore.
