### PR TITLE
Ensure that funcitons exist in Roots_Sidebar

### DIFF
--- a/lib/sidebar.php
+++ b/lib/sidebar.php
@@ -33,7 +33,11 @@ class Roots_Sidebar {
     if (is_array($conditional_tag)) {
       return $conditional_tag[0]($conditional_tag[1]);
     } else {
-      return $conditional_tag();
+      if (function_exists($conditional_tag)) {
+        return $conditional_tag();
+      } else {
+        return false;
+      }
     }
   }
 


### PR DESCRIPTION
I added a check around the $conditional_tag(); in the sidebar to ensure that the function exists-- I was getting a 500 on a woocommerce theme when running it without the plugin enabled.  This enables me to set functions like is_cart that are implemented in plugins and have the theme function without activating the plugins.
