### PR TITLE
Author Archives title - WPML Compatibility

### DIFF
--- a/lib/titles.php
+++ b/lib/titles.php
@@ -23,7 +23,7 @@ function roots_title() {
       return sprintf(__('Yearly Archives: %s', 'roots'), get_the_date('Y'));
     } elseif (is_author()) {
       $author = get_queried_object();
-      return sprintf(__('Author Archives: %s', 'roots'), $author->display_name);
+      return sprintf(__('Author Archives: %s', 'roots'), apply_filters('the_author', is_object($author) ? $author->display_name : null));
     } else {
       return single_cat_title('', false);
     }


### PR DESCRIPTION
If WPML String Translation is used to have multilingual author names, this change is needed to persist the translation to the title of the Author Archives page.

Syntax copied from author-template.php in the WordPress codebase.
