### PR TITLE
Remove stray </div>

### DIFF
--- a/lib/comments.php
+++ b/lib/comments.php
@@ -38,7 +38,7 @@ class Roots_Walker_Comment extends Walker_Comment {
       call_user_func($args['end-callback'], $comment, $args, $depth);
       return;
     }
-    echo "</div></li>\n";
+    echo "</li>\n";
   }
 }
 


### PR DESCRIPTION
end_el prints </div></li> but start_el only prints <li ...> before including templates/comment.php.
