### PR TITLE
Bug in roots_request_filter()

### DIFF
--- a/lib/cleanup.php
+++ b/lib/cleanup.php
@@ -242,7 +242,7 @@ if (current_theme_supports('nice-search')) {
  * @link http://core.trac.wordpress.org/ticket/11330
  */
 function roots_request_filter($query_vars) {
-  if (isset($_GET['s']) && empty($_GET['s'])) {
+  if (isset($_GET['s']) && empty($_GET['s']) && !is_admin()) {
     $query_vars['s'] = ' ';
   }
 


### PR DESCRIPTION
This function affects the dashboard as well and breaks product filtering in WooCommerce 2.15 (not sure what other versions). Adding && !is_admin() should fix it.
