### PR TITLE
Fix comment log out title echo

### DIFF
--- a/templates/comments.php
+++ b/templates/comments.php
@@ -51,7 +51,7 @@
         <?php if (is_user_logged_in()) : ?>
           <p>
             <?php printf(__('Logged in as <a href="%s/wp-admin/profile.php">%s</a>.', 'roots'), get_option('siteurl'), $user_identity); ?>
-            <a href="<?php echo wp_logout_url(get_permalink()); ?>" title="<?php __('Log out of this account', 'roots'); ?>"><?php _e('Log out &raquo;', 'roots'); ?></a>
+            <a href="<?php echo wp_logout_url(get_permalink()); ?>" title="<?php _e('Log out of this account', 'roots'); ?>"><?php _e('Log out &raquo;', 'roots'); ?></a>
           </p>
         <?php else : ?>
           <div class="form-group">


### PR DESCRIPTION
Noticed the comment log out title wasn't being echo'd.
