### PR TITLE
Move comments.php conditionals inside <section> tags to ensure comments_link() does not break (and clean up spacing)

### DIFF
--- a/templates/comments.php
+++ b/templates/comments.php
@@ -2,9 +2,10 @@
   if (post_password_required()) {
     return;
   }
+?>
 
- if (have_comments()) : ?>
-  <section id="comments">
+<section id="comments">
+  <?php if (have_comments()) : ?>
     <h3><?php printf(_n('One Response to &ldquo;%2$s&rdquo;', '%1$s Responses to &ldquo;%2$s&rdquo;', get_comments_number(), 'roots'), number_format_i18n(get_comments_number()), get_the_title()); ?></h3>
 
     <ol class="media-list">
@@ -12,36 +13,32 @@
     </ol>
 
     <?php if (get_comment_pages_count() > 1 && get_option('page_comments')) : ?>
-    <nav>
-      <ul class="pager">
-        <?php if (get_previous_comments_link()) : ?>
-          <li class="previous"><?php previous_comments_link(__('&larr; Older comments', 'roots')); ?></li>
-        <?php endif; ?>
-        <?php if (get_next_comments_link()) : ?>
-          <li class="next"><?php next_comments_link(__('Newer comments &rarr;', 'roots')); ?></li>
-        <?php endif; ?>
-      </ul>
-    </nav>
+      <nav>
+        <ul class="pager">
+          <?php if (get_previous_comments_link()) : ?>
+            <li class="previous"><?php previous_comments_link(__('&larr; Older comments', 'roots')); ?></li>
+          <?php endif; ?>
+          <?php if (get_next_comments_link()) : ?>
+            <li class="next"><?php next_comments_link(__('Newer comments &rarr;', 'roots')); ?></li>
+          <?php endif; ?>
+        </ul>
+      </nav>
     <?php endif; ?>
 
     <?php if (!comments_open() && !is_page() && post_type_supports(get_post_type(), 'comments')) : ?>
-    <div class="alert alert-warning">
-      <?php _e('Comments are closed.', 'roots'); ?>
-    </div>
+      <div class="alert alert-warning">
+        <?php _e('Comments are closed.', 'roots'); ?>
+      </div>
     <?php endif; ?>
-  </section><!-- /#comments -->
-<?php endif; ?>
-
-<?php if (!have_comments() && !comments_open() && !is_page() && post_type_supports(get_post_type(), 'comments')) : ?>
-  <section id="comments">
+  <?php elseif(!comments_open() && !is_page() && post_type_supports(get_post_type(), 'comments')) : ?>
     <div class="alert alert-warning">
       <?php _e('Comments are closed.', 'roots'); ?>
     </div>
-  </section><!-- /#comments -->
-<?php endif; ?>
+  <?php endif; ?>
+</section><!-- /#comments -->
 
-<?php if (comments_open()) : ?>
-  <section id="respond">
+<section id="respond">
+  <?php if (comments_open()) : ?>
     <h3><?php comment_form_title(__('Leave a Reply', 'roots'), __('Leave a Reply to %s', 'roots')); ?></h3>
     <p class="cancel-comment-reply"><?php cancel_comment_reply_link(); ?></p>
     <?php if (get_option('comment_registration') && !is_user_logged_in()) : ?>
@@ -76,5 +73,5 @@
         <?php do_action('comment_form', $post->ID); ?>
       </form>
     <?php endif; ?>
-  </section><!-- /#respond -->
-<?php endif; ?>
+  <?php endif; ?>
+</section><!-- /#respond -->


### PR DESCRIPTION
See https://github.com/roots/roots/issues/1018
