### PR TITLE
Trigger an error when a required include fails to be included...

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2,18 +2,29 @@
 /**
  * Roots includes
  */
-require_once locate_template('/lib/utils.php');           // Utility functions
-require_once locate_template('/lib/init.php');            // Initial theme setup and constants
-require_once locate_template('/lib/wrapper.php');         // Theme wrapper class
-require_once locate_template('/lib/sidebar.php');         // Sidebar class
-require_once locate_template('/lib/config.php');          // Configuration
-require_once locate_template('/lib/activation.php');      // Theme activation
-require_once locate_template('/lib/titles.php');          // Page titles
-require_once locate_template('/lib/cleanup.php');         // Cleanup
-require_once locate_template('/lib/nav.php');             // Custom nav modifications
-require_once locate_template('/lib/gallery.php');         // Custom [gallery] modifications
-require_once locate_template('/lib/comments.php');        // Custom comments modifications
-require_once locate_template('/lib/relative-urls.php');   // Root relative URLs
-require_once locate_template('/lib/widgets.php');         // Sidebars and widgets
-require_once locate_template('/lib/scripts.php');         // Scripts and stylesheets
-require_once locate_template('/lib/custom.php');          // Custom functions
+$roots_includes = array(
+  '/lib/utils.php',           // Utility functions
+  '/lib/init.php',            // Initial theme setup and constants
+  '/lib/wrapper.php',         // Theme wrapper class
+  '/lib/sidebar.php',         // Sidebar class
+  '/lib/config.php',          // Configuration
+  '/lib/activation.php',      // Theme activation
+  '/lib/titles.php',          // Page titles
+  '/lib/cleanup.php',         // Cleanup
+  '/lib/nav.php',             // Custom nav modifications
+  '/lib/gallery.php',         // Custom [gallery] modifications
+  '/lib/comments.php',        // Custom comments modifications
+  '/lib/relative-urls.php',   // Root relative URLs
+  '/lib/widgets.php',         // Sidebars and widgets
+  '/lib/scripts.php',         // Scripts and stylesheets
+  '/lib/custom.php',          // Custom functions
+);
+
+foreach($roots_includes as $file){
+  if(!$filepath = locate_template($file)) {
+    trigger_error("Error locating `$file` for inclusion!", E_USER_ERROR);
+  }
+
+  require_once $filepath;
+}
+unset($file, $filepath);


### PR DESCRIPTION
I encountered this while attmepting to deploy a Roots-based theme to @WPEngine via git. A global `.gitignore` rule omitted the contents of `roots/lib/` from the index, so none of the `require_once` lines from `functions.php` worked. The `locate_template()` function can `require` the file, given appropriate flags, and returns an empty string if it can't find it. More useful would be an error message when this occurs. Whether this deserves `E_USER_ERROR`, `E_USER_WARNING` or `E_USER_NOTICE` is a subject for debate. Please advise.
