### PR TITLE
Add "collapsed" default class to navbar collapse button

### DIFF
--- a/templates/header.php
+++ b/templates/header.php
@@ -1,7 +1,7 @@
 <header class="banner navbar navbar-default navbar-static-top" role="banner">
   <div class="container">
     <div class="navbar-header">
-      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target=".navbar-collapse">
         <span class="sr-only">Toggle navigation</span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>


### PR DESCRIPTION
The button for the collapsible navbar currently gets  the "collapsed" class added only after one complete expand/collapse cycle. For styling and consistency, it should have this class by default.
