### PR TITLE
Retrieve manifest.json from local file system. Fixes  #1048

### DIFF
--- a/lib/scripts.php
+++ b/lib/scripts.php
@@ -20,7 +20,7 @@ function roots_scripts() {
    * Read the asset names from assets-manifest.json
    */
   if (WP_ENV !== 'development') {
-    $get_assets = file_get_contents(get_template_directory_uri() . '/assets/manifest.json');
+    $get_assets = file_get_contents(get_template_directory() . '/assets/manifest.json');
     $assets     = json_decode($get_assets, true);
     $assets     = array(
       'css'       => '/assets/css/main.min.css' . '?' . $assets['assets/css/main.min.css']['hash'],


### PR DESCRIPTION
I simply replaced `get_template_directory_uri()` with `get_template_directory()` so that `file_get_contents()` doesn't try to retrieve the file over the network. Instead it will load it from the local file system.

I haven't tested this, but I'm going to assume it works.
