### PR TITLE
Remove footer copyright element

### DIFF
--- a/templates/footer.php
+++ b/templates/footer.php
@@ -1,7 +1,6 @@
 <footer class="content-info" role="contentinfo">
   <div class="container">
     <?php dynamic_sidebar('sidebar-footer'); ?>
-    <p>&copy; <?php echo date('Y'); ?> <?php bloginfo('name'); ?></p>
   </div>
 </footer>
 


### PR DESCRIPTION
What would be the downside of removing the copyright element from the footer?

In my opinion, it would be a better default to remove this and leave it to the user to add a text widget with the copyright information for their site.

This is the only line in the footer that I've had to customize for the sites I've built using roots, for my purposes it would be great if this was removed by default.
