### PR TITLE
Make `grunt watch:js` include `assets/js/plugins/**/*.js`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,6 +131,7 @@ module.exports = function(grunt) {
       },
       js: {
         files: [
+          jsFileList,
           '<%= jshint.all %>'
         ],
         tasks: ['jshint', 'concat']


### PR DESCRIPTION
If I add JavaScript packages to my `assets/js/plugins/` directory, they must be concatenated, uglified, and added to `scripts.js` to be used in my theme. The `watch:js` task should also note changes to those files and directories.
