### PR TITLE
Use max-width for captions

### DIFF
--- a/lib/cleanup.php
+++ b/lib/cleanup.php
@@ -158,7 +158,7 @@ function roots_caption($output, $attr, $content) {
   // Set up the attributes for the caption <figure>
   $attributes  = (!empty($attr['id']) ? ' id="' . esc_attr($attr['id']) . '"' : '' );
   $attributes .= ' class="thumbnail wp-caption ' . esc_attr($attr['align']) . '"';
-  $attributes .= ' style="width: ' . (esc_attr($attr['width']) + 10) . 'px"';
+  $attributes .= ' style="max-width: ' . (esc_attr($attr['width']) + 10) . 'px"';
 
   $output  = '<figure' . $attributes .'>';
   $output .= do_shortcode($content);


### PR DESCRIPTION
Prior to this commit the CSS property for caption width was set to `width`. This restricts Bootstrap's .img-responsive for responsive images. Now this property is replaced with `max-width` to let the images shrink to smaller than their configured size.
