### PR TITLE
Use `get_comment_date` instead of `comment_date`

### DIFF
--- a/templates/comment.php
+++ b/templates/comment.php
@@ -1,7 +1,7 @@
 <?php echo get_avatar($comment, $size = '64'); ?>
 <div class="media-body">
   <h4 class="media-heading"><?php echo get_comment_author_link(); ?></h4>
-  <time datetime="<?php echo comment_date('c'); ?>"><a href="<?php echo htmlspecialchars(get_comment_link($comment->comment_ID)); ?>"><?php printf(__('%1$s', 'roots'), get_comment_date(),  get_comment_time()); ?></a></time>
+  <time datetime="<?php echo get_comment_date('c'); ?>"><a href="<?php echo htmlspecialchars(get_comment_link($comment->comment_ID)); ?>"><?php printf(__('%1$s', 'roots'), get_comment_date(),  get_comment_time()); ?></a></time>
   <?php edit_comment_link(__('(Edit)', 'roots'), '', ''); ?>
 
   <?php if ($comment->comment_approved == '0') : ?>


### PR DESCRIPTION
Because `comment_date` already displays / echo's it value.  
http://codex.wordpress.org/Function_Reference/comment_date  
http://codex.wordpress.org/Function_Reference/get_comment_date
