### PR TITLE
Escaping home_url

### DIFF
--- a/templates/header.php
+++ b/templates/header.php
@@ -1,7 +1,7 @@
 <header class="banner container" role="banner">
   <div class="row">
     <div class="col-lg-12">
-      <a class="brand" href="<?php echo home_url('/') ?>"><?php bloginfo('name'); ?></a>
+      <a class="brand" href="<?php echo esc_url(home_url('/'));  ?>"><?php bloginfo('name'); ?></a>
       <nav class="nav-main" role="navigation">
         <?php
           if (has_nav_menu('primary_navigation')) :


### PR DESCRIPTION
Apparently this is important, according to WP VIP. It's also how underscores does it: https://github.com/Automattic/_s/blob/master/header.php#L27

Most WP functions escape user input, but I guess not this one.
