### PR TITLE
Fix HTML5 Validator Error

### DIFF
--- a/templates/head.php
+++ b/templates/head.php
@@ -1,8 +1,8 @@
+<?php header('X-UA-Compatible: IE=edge');?>
 <!DOCTYPE html>
 <html class="no-js" <?php language_attributes(); ?>>
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title><?php wp_title('|', true, 'right'); ?></title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
Prior to this commit the W3 HTML5 validator (http://validator.w3.org/) returns a “Bad value X-UA-Compatible for attribute http-equiv on element meta.”.

This commit moves this meta attribute to a HTTP header

Yes, this is nitpicking - but it is annoying to get a red flag when everything else is green. There have been several discussions about this over at the HTML5 boilerplate project, but that is about a IE conditional, that does not work.
