### PR TITLE
Bump NPM package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,17 +23,17 @@
     "node": ">= 0.10.0"
   },
   "devDependencies": {
-    "bower": "~1.2.8",
-    "grunt": "~0.4.2",
-    "grunt-autoprefixer": "~0.7.3",
+    "bower": "~1.3.5",
+    "grunt": "~0.4.5",
+    "grunt-autoprefixer": "~0.8.0",
     "grunt-contrib-concat": "~0.4.0",
     "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-less": "~0.11.0",
-    "grunt-contrib-uglify": "~0.4.0",
+    "grunt-contrib-less": "~0.11.3",
+    "grunt-contrib-uglify": "~0.5.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-modernizr": "~0.5.2",
     "grunt-wp-assets": "~0.2.6",
-    "load-grunt-tasks": "~0.4.0",
-    "time-grunt": "~0.3.1"
+    "load-grunt-tasks": "~0.6.0",
+    "time-grunt": "~0.3.2"
   }
 }


### PR DESCRIPTION
-    "bower": "~1.3.5",
-    "grunt": "~0.4.5",
-    "grunt-autoprefixer": "~0.8.0",
-    "grunt-contrib-less": "~0.11.3",
-    "grunt-contrib-uglify": "~0.5.0",
-    "load-grunt-tasks": "~0.6.0",
-    "time-grunt": "~0.3.2"
