### PR TITLE
Initiate the loop for template-custom.php

### DIFF
--- a/template-custom.php
+++ b/template-custom.php
@@ -4,5 +4,7 @@ Template Name: Custom Template
 */
 ?>
 
-<?php get_template_part('templates/page', 'header'); ?>
-<?php get_template_part('templates/content', 'page'); ?>
+<?php while (have_posts()) : the_post(); ?>
+  <?php get_template_part('templates/page', 'header'); ?>
+  <?php get_template_part('templates/content', 'page'); ?>
+<?php endwhile; ?>


### PR DESCRIPTION
I think `template-custom.php` lost the start of its loop when #1056 moved the loop-start from `templates/content-page.php` to `page.php`. A resulting problem is that `the_content()` would be empty when using the Custom Template.

This commit adds a loop-start to `template-custom.php`, mirroring the change #1056 made to `page.php`.
