### PR TITLE
Update autoprefixer map option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,7 +83,9 @@ module.exports = function(grunt) {
       },
       dev: {
         options: {
-          map: 'assets/css/'
+          map: {
+            prev: 'assets/css/'
+          }
         },
         src: 'assets/css/main.css'
       },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "bower": "~1.3.5",
     "grunt": "~0.4.5",
-    "grunt-autoprefixer": "~0.8.0",
+    "grunt-autoprefixer": "~0.8.1",
     "grunt-contrib-concat": "~0.4.0",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-less": "~0.11.3",


### PR DESCRIPTION
Accommodate grunt-autoprefixer's options refactor (in 0.8.0) by passing an object (instead of string) to the map option (a la nDmitry/grunt-autoprefixer@c658fb7 and nDmitry/grunt-autoprefixer@1b7af91). I don't think the sourcemap will work otherwise. 
