### PR TITLE
hide WP_ENV constant notice in debug mode

### DIFF
--- a/lib/scripts.php
+++ b/lib/scripts.php
@@ -19,21 +19,23 @@ function roots_scripts() {
    * The build task in Grunt renames production assets with a hash
    * Read the asset names from assets-manifest.json
    */
-  if (WP_ENV === 'development') {
-    $assets = array(
-      'css'       => '/assets/css/main.css',
-      'js'        => '/assets/js/scripts.js',
-      'modernizr' => '/assets/vendor/modernizr/modernizr.js',
-      'jquery'    => '//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.js'
-    );
+  if (defined('WP_ENV')) {
+    if (WP_ENV === 'development') {
+      $assets = array(
+        'css' => '/assets/css/main.css',
+        'js' => '/assets/js/scripts.js',
+        'modernizr' => '/assets/vendor/modernizr/modernizr.js',
+        'jquery' => '//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.js'
+      );
+    }
   } else {
     $get_assets = file_get_contents(get_template_directory() . '/assets/manifest.json');
-    $assets     = json_decode($get_assets, true);
-    $assets     = array(
-      'css'       => '/assets/css/main.min.css' . '?' . $assets['assets/css/main.min.css']['hash'],
-      'js'        => '/assets/js/scripts.min.js' . '?' . $assets['assets/js/scripts.min.js']['hash'],
+    $assets = json_decode($get_assets, true);
+    $assets = array(
+      'css' => '/assets/css/main.min.css' . '?' . $assets['assets/css/main.min.css']['hash'],
+      'js' => '/assets/js/scripts.min.js' . '?' . $assets['assets/js/scripts.min.js']['hash'],
       'modernizr' => '/assets/js/vendor/modernizr.min.js',
-      'jquery'    => '//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js'
+      'jquery' => '//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js'
     );
   }
 


### PR DESCRIPTION
WP_ENV constant in wp debug mode generate this note:
Notice: Use of undefined constant WP_ENV - assumed 'WP_ENV' in
C:\xampp\htdocs\wordpress\wp-content\themes\roots\lib\scripts.php on
line 25
and by new if check solve
