### PR TITLE
Move <main> and .sidebar markup out of PHP and into LESS

### DIFF
--- a/assets/less/_variables.less
+++ b/assets/less/_variables.less
@@ -8,3 +8,7 @@
 // -------------------------
 
 @icon-font-path:        "../vendor/bootstrap/fonts/";
+
+@main-sm-columns:       @grid-columns;
+
+@sidebar-sm-columns:    4;

--- a/assets/less/layouts/_general.less
+++ b/assets/less/layouts/_general.less
@@ -2,4 +2,9 @@
 .wrap { }
 
 // Main content area
-.main { }
+.main {
+  .make-sm-column(@main-sm-columns);
+  .sidebar-primary & {
+    .make-sm-column(@main-sm-columns - @sidebar-sm-columns);
+  }
+}

--- a/assets/less/layouts/_sidebar.less
+++ b/assets/less/layouts/_sidebar.less
@@ -1,1 +1,3 @@
-.sidebar { }
+.sidebar {
+  .make-sm-column(@sidebar-sm-columns);
+}

--- a/base.php
+++ b/base.php
@@ -14,11 +14,11 @@
 
   <div class="wrap container" role="document">
     <div class="content row">
-      <main class="main <?php echo roots_main_class(); ?>" role="main">
+      <main class="main" role="main">
         <?php include roots_template_path(); ?>
       </main><!-- /.main -->
       <?php if (roots_display_sidebar()) : ?>
-        <aside class="sidebar <?php echo roots_sidebar_class(); ?>" role="complementary">
+        <aside class="sidebar" role="complementary">
           <?php include roots_sidebar_path(); ?>
         </aside><!-- /.sidebar -->
       <?php endif; ?>

--- a/lib/config.php
+++ b/lib/config.php
@@ -14,26 +14,15 @@ add_theme_support('jquery-cdn');            // Enable to load jQuery from the Go
 define('GOOGLE_ANALYTICS_ID', ''); // UA-XXXXX-Y (Note: Universal Analytics only, not Classic Analytics)
 
 /**
- * .main classes
+ * Add body class if sidebar is active
  */
-function roots_main_class() {
+function roots_sidebar_body_class($classes) {
   if (roots_display_sidebar()) {
-    // Classes on pages with the sidebar
-    $class = 'col-sm-8';
-  } else {
-    // Classes on full width pages
-    $class = 'col-sm-12';
+    $classes[] = 'sidebar-primary';
   }
-
-  return apply_filters('roots/main_class', $class);
+  return $classes;
 }
-
-/**
- * .sidebar classes
- */
-function roots_sidebar_class() {
-  return apply_filters('roots/sidebar_class', 'col-sm-4');
-}
+add_filter('body_class', 'roots_sidebar_body_class');
 
 /**
  * Define which pages shouldn't have the sidebar


### PR DESCRIPTION
It's always bothered me that (1) these PHP functions add markup and (2) that they specifically add _Bootstrap_ markup to HTML elements.

Why not move them into LESS?
