### PR TITLE
Add vendor/**/*.less to grunt watch task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -126,8 +126,7 @@ module.exports = function(grunt) {
     watch: {
       less: {
         files: [
-          'assets/less/*.less',
-          'assets/less/**/*.less'
+          'assets/**/*.less'
         ],
         tasks: ['less:dev', 'autoprefixer:dev']
       },


### PR DESCRIPTION
I'm actually unclear whether this was omitted intentionally to discourage directly modifying vendor packages or just a tiny bug?

It seems a bit strange that we now must either manually build or override Bootstrap's LESS...
