### PR TITLE
Added custom sized images to the media manager dropdown selection

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -19,6 +19,9 @@ function roots_setup() {
   // http://codex.wordpress.org/Function_Reference/add_image_size
   add_theme_support('post-thumbnails');
 
+  // Add Custom Image Sizes to the Media Manager Selection
+  add_filter( 'image_size_names_choose', 'roots_insert_custom_image_sizes' );
+
   // Add post formats
   // http://codex.wordpress.org/Post_Formats
   add_theme_support('post-formats', array('aside', 'gallery', 'link', 'image', 'quote', 'video', 'audio'));
@@ -27,6 +30,29 @@ function roots_setup() {
   add_editor_style('/assets/css/editor-style.css');
 }
 add_action('after_setup_theme', 'roots_setup');
+
+
+/**
+ * Add new image sizes to Media Manager
+ */
+function roots_insert_custom_image_sizes( $image_sizes ) {
+  // get the custom image sizes
+  global $_wp_additional_image_sizes;
+  // if there are none, just return the built-in sizes
+  if ( empty( $_wp_additional_image_sizes ) )
+    return $image_sizes;
+
+  // add all the custom sizes to the built-in sizes
+  foreach ( $_wp_additional_image_sizes as $id => $data ) {
+    // take the size ID (e.g., 'my-name'), replace hyphens with spaces,
+    // and capitalise the first letter of each word
+    if ( !isset($image_sizes[$id]) )
+      $image_sizes[$id] = ucfirst( str_replace( '-', ' ', $id ) );
+    }
+
+  return $image_sizes;
+}
+
 
 /**
  * Register sidebars


### PR DESCRIPTION
I needed to be able to select my custom sized images on the post editor screen in the media manager and it was a really simple addon so I added it and sent this pull request.  Hopefully it will be accepted to the Roots project, thank you

The image below shows what it looks like with my custom sized images...

![npm7sbf](https://cloud.githubusercontent.com/assets/186818/3621984/38673f90-0e24-11e4-98c0-bee02cc5d3b2.png)
