### PR TITLE
Use Grunt uglify as substitute for concat

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,16 +61,19 @@ module.exports = function(grunt) {
         }
       }
     },
-    concat: {
-      options: {
-        separator: ';',
-      },
-      dist: {
-        src: [jsFileList],
-        dest: 'assets/js/scripts.js',
-      },
-    },
     uglify: {
+      dev: {
+        options: {
+          beautify: true,
+          compress: false,
+          mangle: false,
+          preserveComments: 'all',
+          report: false,
+        },
+        files: {
+          'assets/js/scripts.js': [jsFileList]
+        }
+      },
       dist: {
         files: {
           'assets/js/scripts.min.js': [jsFileList]
@@ -162,7 +165,7 @@ module.exports = function(grunt) {
     'jshint',
     'less:dev',
     'autoprefixer:dev',
-    'concat'
+    'uglify:dev'
   ]);
   grunt.registerTask('build', [
     'jshint',

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "bower": "~1.3.5",
     "grunt": "~0.4.5",
     "grunt-autoprefixer": "~0.8.1",
-    "grunt-contrib-concat": "~0.4.0",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-less": "~0.11.3",
     "grunt-contrib-uglify": "~0.5.0",


### PR DESCRIPTION
Using `grunt-contrib-uglify`'s available options, it's possible to
closely approximate plain old concatenated files.

Spaces between lines are removed, double quotes become single quotes,
and I'm sure there are other differences. But to me, these minor
differences don't seem to matter when we can completely eliminate
an additional Grunt task.
