### PR TITLE
specify src and dest for grunt concat consistently

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,12 +63,13 @@ module.exports = function(grunt) {
     },
     concat: {
       options: {
-        separator: ';',
+        separator: ';'
       },
       dist: {
-        src: [jsFileList],
-        dest: 'assets/js/scripts.js',
-      },
+        files: {
+          'assets/js/scripts.js': [jsFileList]
+        }
+      }
     },
     uglify: {
       dist: {


### PR DESCRIPTION
The rest of the Gruntfile uses this simplified way of setting `src` and
`dest` files. So should the `concat` task.

I may be wrong, but listing `src` and `dest` separately appears to allow
for only one set of concatenated files.

If my previous PR #1100 is merged, then there's no need for this.
