### PR TITLE
Update _bootstrap.less

### DIFF
--- a/assets/less/_bootstrap.less
+++ b/assets/less/_bootstrap.less
@@ -5,89 +5,89 @@
 // --------------------------------------------------
 
 // Variables
-@import "../vendor/bootstrap/less/variables";
+@import "../../bower_components/bootstrap/less/variables";
 @import "_variables"; // Bootstrap variable overrides and custom variables
 
 // Mixins: Utilities
-@import "../vendor/bootstrap/less/mixins/hide-text";
-@import "../vendor/bootstrap/less/mixins/opacity";
-@import "../vendor/bootstrap/less/mixins/image";
-@import "../vendor/bootstrap/less/mixins/labels";
-@import "../vendor/bootstrap/less/mixins/reset-filter";
-@import "../vendor/bootstrap/less/mixins/resize";
-@import "../vendor/bootstrap/less/mixins/responsive-visibility";
-@import "../vendor/bootstrap/less/mixins/size";
-@import "../vendor/bootstrap/less/mixins/tab-focus";
-@import "../vendor/bootstrap/less/mixins/text-emphasis";
-@import "../vendor/bootstrap/less/mixins/text-overflow";
-@import "../vendor/bootstrap/less/mixins/vendor-prefixes";
+@import "../../bower_components/bootstrap/less/mixins/hide-text";
+@import "../../bower_components/bootstrap/less/mixins/opacity";
+@import "../../bower_components/bootstrap/less/mixins/image";
+@import "../../bower_components/bootstrap/less/mixins/labels";
+@import "../../bower_components/bootstrap/less/mixins/reset-filter";
+@import "../../bower_components/bootstrap/less/mixins/resize";
+@import "../../bower_components/bootstrap/less/mixins/responsive-visibility";
+@import "../../bower_components/bootstrap/less/mixins/size";
+@import "../../bower_components/bootstrap/less/mixins/tab-focus";
+@import "../../bower_components/bootstrap/less/mixins/text-emphasis";
+@import "../../bower_components/bootstrap/less/mixins/text-overflow";
+@import "../../bower_components/bootstrap/less/mixins/vendor-prefixes";
 
 // Mixins: Components
-@import "../vendor/bootstrap/less/mixins/alerts";
-@import "../vendor/bootstrap/less/mixins/buttons";
-@import "../vendor/bootstrap/less/mixins/panels";
-@import "../vendor/bootstrap/less/mixins/pagination";
-@import "../vendor/bootstrap/less/mixins/list-group";
-@import "../vendor/bootstrap/less/mixins/nav-divider";
-@import "../vendor/bootstrap/less/mixins/forms";
-@import "../vendor/bootstrap/less/mixins/progress-bar";
-@import "../vendor/bootstrap/less/mixins/table-row";
+@import "../../bower_components/bootstrap/less/mixins/alerts";
+@import "../../bower_components/bootstrap/less/mixins/buttons";
+@import "../../bower_components/bootstrap/less/mixins/panels";
+@import "../../bower_components/bootstrap/less/mixins/pagination";
+@import "../../bower_components/bootstrap/less/mixins/list-group";
+@import "../../bower_components/bootstrap/less/mixins/nav-divider";
+@import "../../bower_components/bootstrap/less/mixins/forms";
+@import "../../bower_components/bootstrap/less/mixins/progress-bar";
+@import "../../bower_components/bootstrap/less/mixins/table-row";
 
 // Mixins: Skins
-@import "../vendor/bootstrap/less/mixins/background-variant";
-@import "../vendor/bootstrap/less/mixins/border-radius";
-@import "../vendor/bootstrap/less/mixins/gradients";
+@import "../../bower_components/bootstrap/less/mixins/background-variant";
+@import "../../bower_components/bootstrap/less/mixins/border-radius";
+@import "../../bower_components/bootstrap/less/mixins/gradients";
 
 // Mixins: Layout
-@import "../vendor/bootstrap/less/mixins/clearfix";
-@import "../vendor/bootstrap/less/mixins/center-block";
-@import "../vendor/bootstrap/less/mixins/nav-vertical-align";
-@import "../vendor/bootstrap/less/mixins/grid-framework";
-@import "../vendor/bootstrap/less/mixins/grid";
+@import "../../bower_components/bootstrap/less/mixins/clearfix";
+@import "../../bower_components/bootstrap/less/mixins/center-block";
+@import "../../bower_components/bootstrap/less/mixins/nav-vertical-align";
+@import "../../bower_components/bootstrap/less/mixins/grid-framework";
+@import "../../bower_components/bootstrap/less/mixins/grid";
 
 // Reset
-@import "../vendor/bootstrap/less/normalize";
-@import "../vendor/bootstrap/less/print";
-@import "../vendor/bootstrap/less/glyphicons";
+@import "../../bower_components/bootstrap/less/normalize";
+@import "../../bower_components/bootstrap/less/print";
+@import "../../bower_components/bootstrap/less/glyphicons";
 
 // Core CSS
-@import "../vendor/bootstrap/less/scaffolding";
-@import "../vendor/bootstrap/less/type";
-@import "../vendor/bootstrap/less/code";
-@import "../vendor/bootstrap/less/grid";
-@import "../vendor/bootstrap/less/tables";
-@import "../vendor/bootstrap/less/forms";
-@import "../vendor/bootstrap/less/buttons";
+@import "../../bower_components/bootstrap/less/scaffolding";
+@import "../../bower_components/bootstrap/less/type";
+@import "../../bower_components/bootstrap/less/code";
+@import "../../bower_components/bootstrap/less/grid";
+@import "../../bower_components/bootstrap/less/tables";
+@import "../../bower_components/bootstrap/less/forms";
+@import "../../bower_components/bootstrap/less/buttons";
 
 // Components
-@import "../vendor/bootstrap/less/component-animations";
-@import "../vendor/bootstrap/less/dropdowns";
-@import "../vendor/bootstrap/less/button-groups";
-@import "../vendor/bootstrap/less/input-groups";
-@import "../vendor/bootstrap/less/navs";
-@import "../vendor/bootstrap/less/navbar";
-@import "../vendor/bootstrap/less/breadcrumbs";
-@import "../vendor/bootstrap/less/pagination";
-@import "../vendor/bootstrap/less/pager";
-@import "../vendor/bootstrap/less/labels";
-@import "../vendor/bootstrap/less/badges";
-@import "../vendor/bootstrap/less/jumbotron";
-@import "../vendor/bootstrap/less/thumbnails";
-@import "../vendor/bootstrap/less/alerts";
-@import "../vendor/bootstrap/less/progress-bars";
-@import "../vendor/bootstrap/less/media";
-@import "../vendor/bootstrap/less/list-group";
-@import "../vendor/bootstrap/less/panels";
-@import "../vendor/bootstrap/less/responsive-embed";
-@import "../vendor/bootstrap/less/wells";
-@import "../vendor/bootstrap/less/close";
+@import "../../bower_components/bootstrap/less/component-animations";
+@import "../../bower_components/bootstrap/less/dropdowns";
+@import "../../bower_components/bootstrap/less/button-groups";
+@import "../../bower_components/bootstrap/less/input-groups";
+@import "../../bower_components/bootstrap/less/navs";
+@import "../../bower_components/bootstrap/less/navbar";
+@import "../../bower_components/bootstrap/less/breadcrumbs";
+@import "../../bower_components/bootstrap/less/pagination";
+@import "../../bower_components/bootstrap/less/pager";
+@import "../../bower_components/bootstrap/less/labels";
+@import "../../bower_components/bootstrap/less/badges";
+@import "../../bower_components/bootstrap/less/jumbotron";
+@import "../../bower_components/bootstrap/less/thumbnails";
+@import "../../bower_components/bootstrap/less/alerts";
+@import "../../bower_components/bootstrap/less/progress-bars";
+@import "../../bower_components/bootstrap/less/media";
+@import "../../bower_components/bootstrap/less/list-group";
+@import "../../bower_components/bootstrap/less/panels";
+@import "../../bower_components/bootstrap/less/responsive-embed";
+@import "../../bower_components/bootstrap/less/wells";
+@import "../../bower_components/bootstrap/less/close";
 
 // Components w/ JavaScript
-@import "../vendor/bootstrap/less/modals";
-@import "../vendor/bootstrap/less/tooltip";
-@import "../vendor/bootstrap/less/popovers";
-@import "../vendor/bootstrap/less/carousel";
+@import "../../bower_components/bootstrap/less/modals";
+@import "../../bower_components/bootstrap/less/tooltip";
+@import "../../bower_components/bootstrap/less/popovers";
+@import "../../bower_components/bootstrap/less/carousel";
 
 // Utility classes
-@import "../vendor/bootstrap/less/utilities";
-@import "../vendor/bootstrap/less/responsive-utilities";
+@import "../../bower_components/bootstrap/less/utilities";
+@import "../../bower_components/bootstrap/less/responsive-utilities";


### PR DESCRIPTION
Is the **vendor** folder still created after **bower** runs? 

The folder I see created with all the less mixins exists within the **bower_components** folder.

[more info...](https://github.com/roots/roots/issues/1078)
