### PR TITLE
use WP HTML5 markup for captions instead of Soil

### DIFF
--- a/assets/less/components/_media.less
+++ b/assets/less/components/_media.less
@@ -3,6 +3,10 @@
   &:extend(.thumbnail all);
 }
 
+.wp-caption-text {
+    &:extend(.thumbnail .caption);
+}
+
 // Gallery shortcode
 .gallery-row {
   padding: (@line-height-computed / 2) 0;

--- a/lib/init.php
+++ b/lib/init.php
@@ -23,6 +23,10 @@ function roots_setup() {
   // http://codex.wordpress.org/Post_Formats
   add_theme_support('post-formats', array('aside', 'gallery', 'link', 'image', 'quote', 'video', 'audio'));
 
+  // Add HTML5 markup for captions
+  // http://codex.wordpress.org/Function_Reference/add_theme_support#HTML5
+  add_theme_support('html5', array('caption'));
+
   // Tell the TinyMCE editor to use a custom stylesheet
   add_editor_style('/assets/css/editor-style.css');
 }


### PR DESCRIPTION
Use `add_theme_support` to enable native HTML5 captions and filter the
caption shortcode to add in the caption class from Bootstrap.

There is a potentially simpler way to achieve this by adding Bootstrap caption styles to `wp-caption-text` class and not filtering the caption shortcode. Also not sure if you want this to live in extras.php.

To complete this merge, the `soil_caption` function needs to be removed from Soil in `modules/clean-up.php` per the discussion at roots/soil/issues/25
