### PR TITLE
Check sidebar conditional tag exists

### DIFF
--- a/lib/sidebar.php
+++ b/lib/sidebar.php
@@ -30,10 +30,13 @@ class Roots_Sidebar {
   }
 
   private function check_conditional_tag($conditional_tag) {
-    if (is_array($conditional_tag)) {
-      return $conditional_tag[0]($conditional_tag[1]);
+    $conditional_arg = is_array($conditional_tag) ? $conditional_tag[1] : false;
+    $conditional_tag = $conditional_arg ? $conditional_tag[0] : $conditional_tag;
+
+    if (function_exists($conditional_tag)) {
+      return $conditional_arg ? $conditional_tag($conditional_arg) : $conditional_tag();
     } else {
-      return $conditional_tag();
+      return false;
     }
   }
 


### PR DESCRIPTION
Return false for non-existent conditional tags. Fixes #993
