### PR TITLE
Update Sidebar to fix default template check

### DIFF
--- a/lib/sidebar.php
+++ b/lib/sidebar.php
@@ -41,6 +41,6 @@ class Roots_Sidebar {
   }
 
   private function check_page_template($page_template) {
-    return is_page_template($page_template);
+    return is_page_template($page_template) || Roots_Wrapping::$base . '.php' === $page_template;
   }
 }


### PR DESCRIPTION
This fixes the template check so that adding `page.php` to the array of excluded templates in `$sidebar_config` results in the intended behavior (no sidebar).

See http://wordpress.org/support/topic/is_page_template-refuses-to-acknowledge-the-default-page-template
