### PR TITLE
Gulp has arrived!

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,112 +1,9 @@
 'use strict';
 module.exports = function(grunt) {
-  // Load all tasks
-  require('load-grunt-tasks')(grunt);
-  // Show elapsed time
-  require('time-grunt')(grunt);
 
-  var jsFileList = [
-    'assets/vendor/bootstrap/js/transition.js',
-    'assets/vendor/bootstrap/js/alert.js',
-    'assets/vendor/bootstrap/js/button.js',
-    'assets/vendor/bootstrap/js/carousel.js',
-    'assets/vendor/bootstrap/js/collapse.js',
-    'assets/vendor/bootstrap/js/dropdown.js',
-    'assets/vendor/bootstrap/js/modal.js',
-    'assets/vendor/bootstrap/js/tooltip.js',
-    'assets/vendor/bootstrap/js/popover.js',
-    'assets/vendor/bootstrap/js/scrollspy.js',
-    'assets/vendor/bootstrap/js/tab.js',
-    'assets/vendor/bootstrap/js/affix.js',
-    'assets/js/plugins/*.js',
-    'assets/js/_*.js'
-  ];
+  grunt.loadNpmTasks('grunt-wp-assets');
 
   grunt.initConfig({
-    jshint: {
-      options: {
-        jshintrc: '.jshintrc'
-      },
-      all: [
-        'Gruntfile.js',
-        'assets/js/*.js',
-        '!assets/js/scripts.js',
-        '!assets/**/*.min.*'
-      ]
-    },
-    less: {
-      dev: {
-        files: {
-          'assets/css/main.css': [
-            'assets/less/main.less'
-          ]
-        },
-        options: {
-          compress: false,
-          // LESS source map
-          // To enable, set sourceMap to true and update sourceMapRootpath based on your install
-          sourceMap: true,
-          sourceMapFilename: 'assets/css/main.css.map',
-          sourceMapRootpath: '/app/themes/roots/'
-        }
-      },
-      build: {
-        files: {
-          'assets/css/main.min.css': [
-            'assets/less/main.less'
-          ]
-        },
-        options: {
-          compress: true
-        }
-      }
-    },
-    concat: {
-      options: {
-        separator: ';',
-      },
-      dist: {
-        src: [jsFileList],
-        dest: 'assets/js/scripts.js',
-      },
-    },
-    uglify: {
-      dist: {
-        files: {
-          'assets/js/scripts.min.js': [jsFileList]
-        }
-      }
-    },
-    autoprefixer: {
-      options: {
-        browsers: ['last 2 versions', 'ie 8', 'ie 9', 'android 2.3', 'android 4', 'opera 12']
-      },
-      dev: {
-        options: {
-          map: {
-            prev: 'assets/css/'
-          }
-        },
-        src: 'assets/css/main.css'
-      },
-      build: {
-        src: 'assets/css/main.min.css'
-      }
-    },
-    modernizr: {
-      build: {
-        devFile: 'assets/vendor/modernizr/modernizr.js',
-        outputFile: 'assets/js/vendor/modernizr.min.js',
-        files: {
-          'src': [
-            ['assets/js/scripts.min.js'],
-            ['assets/css/main.min.css']
-          ]
-        },
-        uglify: true,
-        parseFiles: true
-      }
-    },
     version: {
       default: {
         options: {
@@ -122,54 +19,7 @@ module.exports = function(grunt) {
           'lib/scripts.php': 'assets/{css,js}/{main,scripts}.min.{css,js}'
         }
       }
-    },
-    watch: {
-      less: {
-        files: [
-          'assets/less/*.less',
-          'assets/less/**/*.less'
-        ],
-        tasks: ['less:dev', 'autoprefixer:dev']
-      },
-      js: {
-        files: [
-          jsFileList,
-          '<%= jshint.all %>'
-        ],
-        tasks: ['jshint', 'concat']
-      },
-      livereload: {
-        // Browser live reloading
-        // https://github.com/gruntjs/grunt-contrib-watch#live-reloading
-        options: {
-          livereload: false
-        },
-        files: [
-          'assets/css/main.css',
-          'assets/js/scripts.js',
-          'templates/*.php',
-          '*.php'
-        ]
-      }
     }
   });
 
-  // Register tasks
-  grunt.registerTask('default', [
-    'dev'
-  ]);
-  grunt.registerTask('dev', [
-    'jshint',
-    'less:dev',
-    'autoprefixer:dev',
-    'concat'
-  ]);
-  grunt.registerTask('build', [
-    'jshint',
-    'less:build',
-    'autoprefixer:build',
-    'uglify',
-    'modernizr',
-    'version'
-  ]);
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,110 @@
+var gulp = require('gulp'),
+  less = require('gulp-less'),
+  autoprefix = require('gulp-autoprefixer'),
+  sourcemaps = require('gulp-sourcemaps'),
+  rename = require('gulp-rename'),
+  concat = require('gulp-concat'),
+  minifyCSS = require('gulp-minify-css'),
+  jshint = require('gulp-jshint'),
+  uglify = require('gulp-uglify'),
+  livereload = require('gulp-livereload'),
+  stylish = require('jshint-stylish'),
+  modernizr = require('gulp-modernizr');
+
+// add all the gruntfile tasks to gulp
+require('gulp-grunt')(gulp);
+
+var paths = {
+  scripts: [
+    'assets/vendor/bootstrap/js/transition.js',
+    'assets/vendor/bootstrap/js/alert.js',
+    'assets/vendor/bootstrap/js/button.js',
+    'assets/vendor/bootstrap/js/carousel.js',
+    'assets/vendor/bootstrap/js/collapse.js',
+    'assets/vendor/bootstrap/js/dropdown.js',
+    'assets/vendor/bootstrap/js/modal.js',
+    'assets/vendor/bootstrap/js/tooltip.js',
+    'assets/vendor/bootstrap/js/popover.js',
+    'assets/vendor/bootstrap/js/scrollspy.js',
+    'assets/vendor/bootstrap/js/tab.js',
+    'assets/vendor/bootstrap/js/affix.js',
+    'assets/js/plugins/*.js',
+    'assets/js/_*.js'
+  ],
+  jshint: [
+    'gulpfile.js',
+    'assets/js/*.js',
+    '!assets/js/scripts.js',
+    '!assets/**/*.min.*'
+  ],
+  less: 'assets/less/main.less'
+};
+
+var destination = {
+  css: 'assets/css',
+  scripts: 'assets/js',
+  modernizr: 'assets/vendor/modernizr',
+  vendor: 'assets/vendor'
+};
+
+
+gulp.task('less', function () {
+  return gulp.src(paths.less)
+    .pipe(sourcemaps.init())
+      .pipe(less()).on('error', function(err){
+        console.warn(err.message);
+      })
+      .pipe(autoprefix('last 2 versions', 'ie 8', 'ie 9', 'android 2.3', 'android 4', 'opera 12'))
+      .pipe(rename('./main.css'))
+    .pipe(sourcemaps.write())
+    .pipe(gulp.dest(destination.css))
+    .pipe(minifyCSS())
+    .pipe(rename('./main.min.css'))
+    .pipe(gulp.dest(destination.css));
+});
+
+gulp.task('jshint', function() {
+  return gulp.src(paths.jshint)
+    .pipe(jshint())
+    .pipe(jshint.reporter(stylish));
+});
+
+gulp.task('js', ['jshint'], function() {
+  return gulp.src(paths.scripts)
+    .pipe(concat('./scripts.js'))
+    .pipe(gulp.dest(destination.scripts))
+    .pipe(uglify())
+    .pipe(rename('./scripts.min.js'))
+    .pipe(gulp.dest(destination.scripts));
+});
+
+gulp.task('modernizr', function() {
+  return gulp.src(
+    ['assets/js/scripts.min.js'],
+    ['assets/css/main.min.css']
+  )
+    .pipe(modernizr())
+    .pipe(gulp.dest(destination.modernizr))
+    .pipe(uglify())
+    .pipe(rename('./modernizr.min.js'))
+    .pipe(gulp.dest(destination.vendor));
+});
+
+gulp.task('version', function() {
+  gulp.run('grunt-version');
+});
+
+gulp.task('watch', function() {
+  livereload.listen();
+
+  gulp.watch('assets/less/**/*.less', ['less']).on('change', livereload.changed);
+  gulp.watch('assets/js/**/*.js', ['jshint', 'js']).on('change', livereload.changed);
+  gulp.watch('**/*.php').on('change', function(file) {
+    livereload.changed(file.path);
+  });
+
+});
+
+gulp.task('default', ['less', 'jshint', 'js', 'modernizr']);
+gulp.task('dev', ['default']);
+gulp.task('build', ['less', 'jshint', 'js', 'modernizr', 'version']);

--- a/package.json
+++ b/package.json
@@ -17,23 +17,26 @@
     }
   ],
   "scripts": {
-    "postinstall": "node node_modules/bower/bin/bower install && grunt dev"
+    "postinstall": "node node_modules/bower/bin/bower install && gulp dev"
   },
   "engines": {
     "node": ">= 0.10.0"
   },
   "devDependencies": {
     "bower": ">=1.3.9",
-    "grunt": "~0.4.5",
-    "grunt-autoprefixer": "~0.8.1",
-    "grunt-contrib-concat": "~0.4.0",
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-less": "~0.11.3",
-    "grunt-contrib-uglify": "~0.5.0",
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-modernizr": "~0.5.2",
-    "grunt-wp-assets": "~0.2.6",
-    "load-grunt-tasks": "~0.6.0",
-    "time-grunt": "~0.3.2"
+    "grunt": "^0.4.5",
+    "grunt-wp-assets": "^0.2.6",
+    "gulp": "^3.8.7",
+    "gulp-autoprefixer": "0.0.8",
+    "gulp-concat": "^2.3.4",
+    "gulp-grunt": "^0.5.2",
+    "gulp-jshint": "^1.8.4",
+    "gulp-less": "^1.3.3",
+    "gulp-livereload": "^2.1.0",
+    "gulp-minify-css": "^0.3.7",
+    "gulp-modernizr": "https://github.com/doctyper/gulp-modernizr/tarball/develop",
+    "gulp-rename": "^1.2.0",
+    "gulp-sourcemaps": "^1.1.1",
+    "gulp-uglify": "^0.3.1"
   }
 }


### PR DESCRIPTION
The gulpfile.js tried to stick closely to the Gruntfile.js, but here are some issues / updates needed:
1. There is no Modernizr gulp plugin yet, so it's using a Github repo. @retlehs suggested just loading Modernizr stock, and wait for a Gulp plugin or for Modernizr 3.0 to launch. This still needs to be implemented.
2. grunt-wp-assets is still being used via Grunt, and Grunt is still included for this reason. @swalkinshaw suggested transitioning to something like [gulp-rev](https://www.npmjs.org/package/gulp-rev)
3. No real difference between dev and build tasks, as they both compile the regular and minified files of CSS and JS.
4. There's not an option to turn livereload on or off like in Grunt. Instead, just run `gulp watch` to watch files and use livereload. There probably is a way to code in an option, but I haven't looked into it deeply yet.
