### PR TITLE
Check for template_include passing non-strings. Fixes #1134

### DIFF
--- a/lib/wrapper.php
+++ b/lib/wrapper.php
@@ -36,6 +36,11 @@ class Roots_Wrapping {
   }
 
   static function wrap($main) {
+    // Check for other filters returning null
+    if (!is_string($main)) {
+      return $main;
+    }
+
     self::$main_template = $main;
     self::$base = basename(self::$main_template, '.php');
 


### PR DESCRIPTION
I agree that the plugin should probably be using exit() and I submitted a bug report. But I don't often get responses on wordpress.org plugin support forums so I thought I'd try my luck here.

To generate the warning ("PHP Warning: include(): Filename cannot be empty in /var/vhosts/.../base.php on line 17"), add this to functions.php and try to load the homepage:

```
add_filter('template_include', function ($template) {
  return null;
});
```

Applying this patch makes that warning go away.

Thanks.
