### PR TITLE
Move wp_footer() from footer template into base.php for easier customization and DRY

### DIFF
--- a/base.php
+++ b/base.php
@@ -27,5 +27,7 @@
 
   <?php get_template_part('templates/footer'); ?>
 
+  <?php wp_footer(); ?>
+
 </body>
 </html>

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -3,5 +3,3 @@
     <?php dynamic_sidebar('sidebar-footer'); ?>
   </div>
 </footer>
-
-<?php wp_footer(); ?>


### PR DESCRIPTION
I needed several custom footer templates and having `wp_footer()` in the default template created some repetition, so why not move it into `base.php` and call it after the content template.
