### PR TITLE
Remove Bootstrap classes from base.php and create equivalent LESS

### DIFF
--- a/assets/less/layouts/_general.less
+++ b/assets/less/layouts/_general.less
@@ -1,5 +1,10 @@
 // Content wrapper
-.wrap { }
+.wrap {
+  &:extend(.container all, .clearfix all);
+  > .content {
+    .make-row();
+  }
+}
 
 // Main content area
 .main {

--- a/base.php
+++ b/base.php
@@ -12,8 +12,8 @@
     get_template_part('templates/header');
   ?>
 
-  <div class="wrap container" role="document">
-    <div class="content row">
+  <div class="wrap" role="document">
+    <div class="content">
       <main class="main" role="main">
         <?php include roots_template_path(); ?>
       </main><!-- /.main -->


### PR DESCRIPTION
I removed the `container` and `row` Bootstrap classes from `base.php` and use the Bootstrap LESS mixins instead.

I realize this is a good step in making Roots framework agnostic but my main intent is to facilitate custom layouts without the need to create a custom base file every time.

For example, a page requiring a full width content area can easily utilize the `:not()` selector on `.wrap` based on body classes.
