### PR TITLE
Reformat str_replace in roots_get_avatar to better match

### DIFF
--- a/lib/comments.php
+++ b/lib/comments.php
@@ -46,7 +46,7 @@ class Roots_Walker_Comment extends Walker_Comment {
 function roots_get_avatar($avatar, $type) {
   if (!is_object($type)) { return $avatar; }
 
-  $avatar = str_replace("class='avatar", "class='avatar pull-left media-object", $avatar);
+  $avatar = str_replace('class="avatar', 'class="avatar pull-left media-object', $avatar);
   return $avatar;
 }
 add_filter('get_avatar', 'roots_get_avatar', 10, 2);


### PR DESCRIPTION
When enabling plugins that also hook get_avatar, such as Buddypress, roots_get_avatar string replace will not match properly on comments in blog posts from "members" of the plugin. This causes some comments to have the class modifications and some do not. 

This pull request better formats the str_replace function quoting so that it matches more reliably.
