### PR TITLE
Remove roots_get_avatar and replace with LESS

### DIFF
--- a/assets/less/components/_comments.less
+++ b/assets/less/components/_comments.less
@@ -1,0 +1,7 @@
+.comment {
+	.avatar {
+		display: block;
+		float: left;
+		margin-right: 10px;
+	}
+}

--- a/assets/less/main.less
+++ b/assets/less/main.less
@@ -7,6 +7,7 @@
 @import "components/_forms";         // Form tweaks
 @import "components/_media";         // WordPress media
 @import "components/_wp-classes";    // WordPress generated classes
+@import "components/_comments";      // Comments styling
 @import "layouts/_general";          // General styling
 @import "layouts/_header";           // Header styling
 @import "layouts/_sidebar";          // Sidebar styling

--- a/lib/comments.php
+++ b/lib/comments.php
@@ -42,11 +42,3 @@ class Roots_Walker_Comment extends Walker_Comment {
     echo "</div></li>\n";
   }
 }
-
-function roots_get_avatar($avatar, $type) {
-  if (!is_object($type)) { return $avatar; }
-
-  $avatar = str_replace("class='avatar", "class='avatar pull-left media-object", $avatar);
-  return $avatar;
-}
-add_filter('get_avatar', 'roots_get_avatar', 10, 2);


### PR DESCRIPTION
This commit replaces the roots_get_avatar function in favor of a LESS solution. Previously the function would sometimes not reliably match in the str_replace, for example when using plugins like Buddypress. 

I have added components/_comments and placed the LESS here, and modified main.less to include the partial.
The roots_get_avatar function has also been removed. 

This solution may only be a gap filler. For roots to be  framework agnostic the comment_walker and the comment template may need to be slightly modified, depending on how that will be accomplished. 
