### PR TITLE
Add roots_body_class function to check for page slug in body_class and add it as needed.

### DIFF
--- a/lib/utils.php
+++ b/lib/utils.php
@@ -21,9 +21,9 @@ add_filter('get_search_form', 'roots_get_search_form');
 function roots_body_class($classes) {
   // Add post/page slug
   if (is_single() || is_page() && !is_front_page()) {
-  	if (!in_array(basename(get_permalink()), $classes)) {
-  		$classes[] = basename(get_permalink());
-  	}
+    if (!in_array(basename(get_permalink()), $classes)) {
+      $classes[] = basename(get_permalink());
+    }
   }
   return $classes;
 }


### PR DESCRIPTION
This PR adds a function `roots_body_class` in `utils.php` that checks for the page slug in body_class and adds it as needed. If it is present already, it skips over. This addresses issue: https://github.com/roots/roots/issues/1164
