### PR TITLE
Move variables into main.less in case it needs to come after other imports (e.g., Fontawesome)

### DIFF
--- a/assets/less/_bootstrap.less
+++ b/assets/less/_bootstrap.less
@@ -6,7 +6,6 @@
 
 // Variables
 @import "../vendor/bootstrap/less/variables";
-@import "_variables"; // Bootstrap variable overrides and custom variables
 
 // Mixins: Utilities
 @import "../vendor/bootstrap/less/mixins/hide-text";

--- a/assets/less/main.less
+++ b/assets/less/main.less
@@ -1,6 +1,9 @@
 // Bootstrap
 @import "_bootstrap";
 
+// Variable overrides and custom variables
+@import "_variables"; 
+
 // Roots
 @import "_global";                   // Base styling & custom mixins
 @import "components/_buttons";       // Button tweaks


### PR DESCRIPTION
I needed to edit some Fontawesome variables and wanted to make the edits to `_variables.less` but the current arrangement left no way to import `_variables.less` _after_ `fontawesome.less` without editing `_bootstrap.less`. IMO the `_variables.less` import belongs in `main.less`.
