### PR TITLE
Manage oEmbed responsive

### DIFF
--- a/lib/extras.php
+++ b/lib/extras.php
@@ -24,8 +24,7 @@ add_filter('wp_title', 'roots_wp_title', 10);
 /**
  * Manage responsive Bootstrap embeds
  */
-add_filter('embed_oembed_html', 'roots_embed_wrap', 10, 3);
-
 function roots_embed_wrap($html, $url, $attr) {
   return "<div class=\"embed-responsive embed-responsive-16by9\">" . $html . "</div>";
 }
+add_filter('embed_oembed_html', 'roots_embed_wrap', 10, 3);


### PR DESCRIPTION
Bootstrap manage the output of responsive embeds:
http://getbootstrap.com/components/#responsive-embed

This simple function wrap the oEmbed HTML with a div with `class="embed-responsive embed-responsive-16by9"` in order to make it responsive.

I know, the size of all oEmbed will be 16/9, I believe is now a big deal because oEmbed shortcode are usually used for videos, and right 16/9 is a kind of standard.

Cheers!
