### PR TITLE
Update hEntry schema to use `updated` instead of `published`

### DIFF
--- a/templates/entry-meta.php
+++ b/templates/entry-meta.php
@@ -1,2 +1,2 @@
-<time class="published" datetime="<?php echo get_the_time('c'); ?>"><?php echo get_the_date(); ?></time>
+<time class="updated" datetime="<?php echo get_the_time('c'); ?>"><?php echo get_the_date(); ?></time>
 <p class="byline author vcard"><?php echo __('By', 'roots'); ?> <a href="<?php echo get_author_posts_url(get_the_author_meta('ID')); ?>" rel="author" class="fn"><?php echo get_the_author(); ?></a></p>


### PR DESCRIPTION
Fixes validation with Google Structured Data Testing Tool. Spec for hEntry on http://microformats.org/wiki/hentry show `updated` as required, and `published` as optional.
