### PR TITLE
Bump Bootstrap SemVer to 3.3.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "modernizr": "2.8.2",
     "jquery": "1.11.1",
-    "bootstrap": "3.2.0",
+    "bootstrap": "3.3.0",
     "respond": "1.4.2"
   }
 }


### PR DESCRIPTION
Simple change to bower.json; haven't seen any conflicts with 3.3.0 with my local development yet. Will report if there are any.
