### PR TITLE
Store display_sidebar in static variable

### DIFF
--- a/lib/config.php
+++ b/lib/config.php
@@ -34,31 +34,36 @@ add_filter('body_class', 'roots_sidebar_body_class');
  * See lib/sidebar.php for more details
  */
 function roots_display_sidebar() {
-  $sidebar_config = new Roots_Sidebar(
-    /**
-     * Conditional tag checks (http://codex.wordpress.org/Conditional_Tags)
-     * Any of these conditional tags that return true won't show the sidebar
-     *
-     * To use a function that accepts arguments, use the following format:
-     *
-     * array('function_name', array('arg1', 'arg2'))
-     *
-     * The second element must be an array even if there's only 1 argument.
-     */
-    array(
-      'is_404',
-      'is_front_page'
-    ),
-    /**
-     * Page template checks (via is_page_template())
-     * Any of these page templates that return true won't show the sidebar
-     */
-    array(
-      'template-custom.php'
-    )
-  );
+  static $display;
 
-  return apply_filters('roots/display_sidebar', $sidebar_config->display);
+  if (!isset($display)) {
+    $sidebar_config = new Roots_Sidebar(
+      /**
+       * Conditional tag checks (http://codex.wordpress.org/Conditional_Tags)
+       * Any of these conditional tags that return true won't show the sidebar
+       *
+       * To use a function that accepts arguments, use the following format:
+       *
+       * array('function_name', array('arg1', 'arg2'))
+       *
+       * The second element must be an array even if there's only 1 argument.
+       */
+      array(
+        'is_404',
+        'is_front_page'
+      ),
+      /**
+       * Page template checks (via is_page_template())
+       * Any of these page templates that return true won't show the sidebar
+       */
+      array(
+        'template-custom.php'
+      )
+    );
+    $display = apply_filters('roots/display_sidebar', $sidebar_config->display);
+  }  
+
+  return $display;
 }
 
 /**


### PR DESCRIPTION
This is for users who might call this function more than once for whatever reason. It ensures that each return from the function is always the same value (so if you hook into the filter, do it before an initial call to `roots_display_sidebar()`).

In addition to that practical benefit, this is also more performant in that each call to the function will no longer create a new `Roots_Sidebar` object, nor will each call to the function run the callbacks for `'roots/display_sidebar'`; these will only be done on the initial call to the function to populate the value of the static variable.
