### PR TITLE
Move wp_head() to be the last markup before </head>

### DIFF
--- a/templates/head.php
+++ b/templates/head.php
@@ -6,7 +6,7 @@
   <title><?php wp_title('|', true, 'right'); ?></title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <?php wp_head(); ?>
-
   <link rel="alternate" type="application/rss+xml" title="<?php echo get_bloginfo('name'); ?> Feed" href="<?php echo esc_url(get_feed_link()); ?>">
+
+  <?php wp_head(); ?>
 </head>


### PR DESCRIPTION
Not sure why this is the way it is, could cause issues with some plugins.
