### PR TITLE
Bump Bootstrap to 3.3.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "modernizr": "2.8.2",
     "jquery": "1.11.1",
-    "bootstrap": "3.3.0",
+    "bootstrap": "3.3.1",
     "respond": "1.4.2"
   }
 }


### PR DESCRIPTION
Just bumpin'. https://github.com/twbs/bootstrap/issues?q=milestone%3Av3.3.1 to see assoc. commits and potentially-squished bugs.
