### PR TITLE
Use del instead of gulp-clean (deprecated)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 /*global $:true*/
 var gulp = require('gulp');
+var del = require('del');
 
 var $ = require('gulp-load-plugins')();
 
@@ -113,9 +114,8 @@ gulp.task('version', function() {
     .pipe(gulp.dest('assets/dist'));
 });
 
-gulp.task('clean', function() {
-  return gulp.src(['assets/dist/css/main.min*', 'assets/dist/js/scripts.min*'], { read: false })
-    .pipe($.clean());
+gulp.task('clean', function (callback) {
+  del(['assets/dist/css/main.min*', 'assets/dist/js/scripts.min*'], callback);
 });
 
 gulp.task('watch', function() {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   },
   "devDependencies": {
     "bower": ">=1.3.9",
+    "del": "^0.1.3",
     "gulp": "^3.8.7",
     "gulp-autoprefixer": "^0.0.7",
-    "gulp-clean": "^0.3.1",
     "gulp-concat": "^2.3.4",
     "gulp-filter": "^0.4.1",
     "gulp-grunt": "^0.5.2",


### PR DESCRIPTION
We use "callback" to ensure the task finishes before exiting.
See: http://markgoodyear.com/2014/01/getting-started-with-gulp/
