### PR TITLE
Remove Roots_Nav_Walker as default for all menu

### DIFF
--- a/lib/nav.php
+++ b/lib/nav.php
@@ -86,10 +86,6 @@ function roots_nav_menu_args($args = '') {
     $roots_nav_menu_args['depth'] = 2;
   }
 
-  if (!$args['walker']) {
-    $roots_nav_menu_args['walker'] = new Roots_Nav_Walker();
-  }
-
   return array_merge($args, $roots_nav_menu_args);
 }
 add_filter('wp_nav_menu_args', 'roots_nav_menu_args');

--- a/templates/header.php
+++ b/templates/header.php
@@ -13,7 +13,7 @@
     <nav class="collapse navbar-collapse" role="navigation">
       <?php
         if (has_nav_menu('primary_navigation')) :
-          wp_nav_menu(array('theme_location' => 'primary_navigation', 'menu_class' => 'nav navbar-nav'));
+          wp_nav_menu(array('theme_location' => 'primary_navigation', 'walker' => new Roots_Nav_Walker(), 'menu_class' => 'nav navbar-nav'));
         endif;
       ?>
     </nav>


### PR DESCRIPTION
I love how `Roots_Nav_Walker()` create menu html.
But, I believe that apply by default to all menus is too much.

Often I use the menu widget to show complex menus with sub-element.
In these situations sub-elements are wrapped in dropdown menus, which is fine for primary menu but not for aside or footer.

I suggest to:
- remove `Roots_Nav_Walker()` as default for all menus
- add `Roots_Nav_Walker()` to Primary menu

In this way:
- if user wants another menu using `Roots_Nav_Walker()`, can simply copy and paste the code in `header.php`
- user can add other custom Nav_Walkers 
- Widget menus can have as many level as user likes.
