### PR TITLE
Clean up page template class in body tag

### DIFF
--- a/lib/utils.php
+++ b/lib/utils.php
@@ -24,7 +24,11 @@ function roots_body_class($classes) {
     if (!in_array(basename(get_permalink()), $classes)) {
       $classes[] = basename(get_permalink());
     }
+    //Clean Up Page Template Class
+    $remove = array("page-template-", "-php"); 
+    $classes = str_replace($remove, "", $classes);
   }
   return $classes;
 }
 add_filter('body_class', 'roots_body_class');
+


### PR DESCRIPTION
This might get shot down, and I'm completely open to discussion, but I wanted to see what the community thought. I will attempt to make my case cleanly below.
### Clean up page template class in Body tag

This PR updates the already present `roots_body_class` function to also clean up the class for page templates.
The default class added for a page template looks like `page-template-template-custom-php`. The patch cleans up the class to be `template-custom`.
#### Pros

The main reason I decided to do this revolves around cleaner code when using the DOM-Routing in javascript to target a specific page template. Instead of:

``` javascript
    page_template_template_custom_php: {
        init: function() {
          // JavaScript to be fired on a page using this template
        }
    }
```

We can instead do: 

``` javascript
    template_custom: {
        init: function() {
          // JavaScript to be fired on a page using this template
        }
    }
```
#### Cons

I haven't tested this extensively against any other plugins, and I am also not sure if any other plugins may depend on the original class. I've never run into one, but I feel it's worth mentioning. 

This change would also possible be breaking to those who attempt to update an already existing theme to a newer version of Roots if they have any routing associated to a template using the old class. 
###### 

Thoughts?
