### PR TITLE
Update and tidy README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,19 @@ Roots is a WordPress starter theme based on [HTML5 Boilerplate](http://html5boil
 * Source: [https://github.com/roots/roots](https://github.com/roots/roots)
 * Homepage: [http://roots.io/](http://roots.io/)
 * Documentation: [http://roots.io/docs/](http://roots.io/docs/)
-* Twitter: [@rootswp](https://twitter.com/rootswp), [@retlehs](https://twitter.com/retlehs), [@swalkinshaw](https://twitter.com/swalkinshaw), [@Foxaii](https://twitter.com/Foxaii), [@c2foryou](https://twitter.com/c2foryou)
+* Twitter: [@rootswp](https://twitter.com/rootswp), [@retlehs](https://twitter.com/retlehs), [@swalkinshaw](https://twitter.com/swalkinshaw), [@Foxaii](https://twitter.com/Foxaii), [@c2foryou](https://twitter.com/c2foryou) [@austinpray](https://twitter.com/austinpray)
 * Newsletter: [Subscribe](http://roots.io/subscribe/)
 * Forum: [http://discourse.roots.io/](http://discourse.roots.io/)
 
 ## Features
 
-* [Gulp](http://gulpjs.com/) for compiling LESS to CSS, checking for JS errors, live reloading, concatenating and minifying files, versioning assets, and generating lean Modernizr builds
+* [gulp](http://gulpjs.com/) for compiling Sass and LESS, checking for JavaScript errors, live reloading, concatenating and minifying files, and versioning assets
 * [Bower](http://bower.io/) for front-end package management
 * [HTML5 Boilerplate](http://html5boilerplate.com/)
   * The latest [jQuery](http://jquery.com/) via Google CDN, with a local fallback
-  * The latest [Modernizr](http://modernizr.com/) build for feature detection, with lean builds with Gulp
+  * The latest [Modernizr](http://modernizr.com/) build for feature detection
   * An optimized Google Analytics snippet
 * [Bootstrap](http://getbootstrap.com/)
-* Organized file and template structure
 * ARIA roles and microformats
 * [Theme activation](http://roots.io/roots-101/#theme-activation)
 * [Theme wrapper](http://roots.io/an-introduction-to-the-roots-theme-wrapper/)
@@ -27,13 +26,21 @@ Roots is a WordPress starter theme based on [HTML5 Boilerplate](http://html5boil
 * Posts use the [hNews](http://microformats.org/wiki/hnews) microformat
 * [Multilingual ready](http://roots.io/wpml/) and over 30 available [community translations](https://github.com/roots/roots-translations)
 
-### Additional features
+### Go further with Roots
 
+#### Clean up WordPress
 Install the [Soil](https://github.com/roots/soil) plugin to enable additional features:
 
 * Root relative URLs
 * Nice search (`/search/query/`)
 * Cleaner output of `wp_head` and enqueued assets markup
+
+#### Modernize your WordPress stack
+[Bedrock](https://github.com/roots/bedrock) gets you started with the best development tools, practices, and project structure.
+
+* Dependency management with Composer
+* Automated deployments with Capistrano
+* Easy environment specific configuration
 
 ## Installation
 
@@ -57,43 +64,40 @@ Edit `lib/init.php` to setup navigation menus, post thumbnail sizes, post format
 
 ## Theme development
 
-Roots uses [Gulp](http://gulpjs.com/) for compiling LESS to CSS, checking for JS errors, live reloading, concatenating and minifying files, versioning assets, and generating lean Modernizr builds.
+Roots uses [gulp](http://gulpjs.com/) as its build system.
 
-If you'd like to use Bootstrap Sass, look at the [Roots Sass](https://github.com/roots/roots-sass) fork.
-
-### Install Gulp
+### Install gulp
 
 **Unfamiliar with npm? Don't have node installed?** [Download and install node.js](http://nodejs.org/download/) before proceeding.
 
 From the command line:
 
-1. Install `gulp` globally with `npm install -g gulp`.
-2. Navigate to the theme directory, then run `npm install`. npm will look at `package.json` and automatically install the necessary dependencies. It will also automatically run `bower install`, which installs front-end packages defined in `bower.json`.
+1. Install [gulp](http://gulpjs.com) and [bower](http://bower.io) globally with `npm install -g gulp bower`.
+2. Navigate to the theme directory, then run `npm install`. 
 
-When completed, you'll be able to run the various Gulp commands provided from the command line.
+You now have all the necessary dependencies to run the build process.
 
-### Available Gulp commands
+### Available gulp commands
 
 * `gulp` — Compile and optimize the files in your assets directory
 * `gulp watch` — Compile assets when file changes are made
-* `gulp --tasks` - Lists all the available tasks and what they do
+* `gulp --tasks` — Lists all the available tasks and what they do
 
 ## Documentation
 
 * [Roots 101](http://roots.io/roots-101/) — A guide to installing Roots, the files, and theme organization
 * [Theme Wrapper](http://roots.io/an-introduction-to-the-roots-theme-wrapper/) — Learn all about the theme wrapper
-* [Build Script](http://roots.io/using-gulp-for-wordpress-theme-development/) — A look into how Roots uses Gulp
+* [Build Script](http://roots.io/using-gulp-for-wordpress-theme-development/) — A look into how Roots uses gulp
 * [Roots Sidebar](http://roots.io/the-roots-sidebar/) — Understand how to display or hide the sidebar in Roots
 
 ## Contributing
 
-Everyone is welcome to help [contribute](CONTRIBUTING.md) and improve this project. There are several ways you can contribute:
+Contributions are welcome from everyone. We have [contributing guidelines](CONTRIBUTING.md) to help you get started. You can help out by:
 
-* Reporting issues (please read [issue guidelines](https://github.com/necolas/issue-guidelines))
-* Suggesting new features
-* Writing or refactoring code
+* Reporting issues (please follow the [issue guidelines](https://github.com/necolas/issue-guidelines))
 * Fixing [issues](https://github.com/roots/roots/issues)
-* Replying to questions on the [forum](http://discourse.roots.io/)
+* Suggesting new features
+* Answering questions on the [forum](http://discourse.roots.io/)
 
 ## Support
 


### PR DESCRIPTION
Removes references to defunct modernizr build generator
Removes repetition
Gulp -> gulp
https://github.com/gulpjs/gulp/blob/master/docs/FAQ.md#is-it-gulp-or-gulp
Removes references to Sass fork, it is dead
Removes "Organized file and template structure" as a feature
Some opinionated usage changes in the Contributing section
Adds my twitter to Readme so I can be reached for gulp stuff
Pimps bedrock
