### PR TITLE
Handle $dist_path as var

### DIFF
--- a/lib/assets.php
+++ b/lib/assets.php
@@ -53,13 +53,14 @@ class JsonManifest {
 }
 
 function asset_path($filename) {
-  $dist_path = get_template_directory_uri() . '/dist/';
+  $dist_var = '/dist/';
+  $dist_path = get_template_directory_uri() . $dist_var;
   $directory = dirname($filename) . '/';
   $file = basename($filename);
   static $manifest;
 
   if (empty($manifest)) {
-    $manifest_path = get_template_directory() . $dist_path . 'assets.json';
+    $manifest_path = get_template_directory() . $dist_var . 'assets.json';
     $manifest = new JsonManifest($manifest_path);
   }
 
@@ -130,7 +131,7 @@ function jquery_local_fallback($src, $handle = null) {
   static $add_jquery_fallback = false;
 
   if ($add_jquery_fallback) {
-    echo '<script>window.jQuery || document.write(\'<script src="' . get_template_directory_uri() . $dist_path . 'scripts/jquery.js"><\/script>\')</script>' . "\n";
+    echo '<script>window.jQuery || document.write(\'<script src="' . get_template_directory_uri() . $dist_var . 'scripts/jquery.js"><\/script>\')</script>' . "\n";
     $add_jquery_fallback = false;
   }
 

--- a/lib/assets.php
+++ b/lib/assets.php
@@ -59,7 +59,7 @@ function asset_path($filename) {
   static $manifest;
 
   if (empty($manifest)) {
-    $manifest_path = get_template_directory() . '/dist/assets.json';
+    $manifest_path = get_template_directory() . $dist_path . 'assets.json';
     $manifest = new JsonManifest($manifest_path);
   }
 
@@ -130,7 +130,7 @@ function jquery_local_fallback($src, $handle = null) {
   static $add_jquery_fallback = false;
 
   if ($add_jquery_fallback) {
-    echo '<script>window.jQuery || document.write(\'<script src="' . get_template_directory_uri() . '/dist/scripts/jquery.js"><\/script>\')</script>' . "\n";
+    echo '<script>window.jQuery || document.write(\'<script src="' . get_template_directory_uri() . $dist_path . 'scripts/jquery.js"><\/script>\')</script>' . "\n";
     $add_jquery_fallback = false;
   }
 
@@ -171,4 +171,3 @@ function google_analytics() {
 if (GOOGLE_ANALYTICS_ID) {
   add_action('wp_footer', __NAMESPACE__ . '\\google_analytics', 20);
 }
-


### PR DESCRIPTION
Based on this thread: https://discourse.roots.io/t/sage-and-augmenting-my-workflow/2965/3

This sets up the opportunity to change the path of `dist/` for those needing to reference a different build.