### PR TITLE
Adds windows compatibilty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 * Fixes broken wiredep imports with main.scss.example ([original issue](https://discourse.roots.io/t/issue-with-sage-sass-version/2962))
+* Adds windows compatibility via asset-builder@1.0.1
 
 ### 8.0.0: February 25th, 2015
 * Change theme name from Roots to Sage

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "npm": ">=2.1.5"
   },
   "devDependencies": {
-    "asset-builder": "^0.4.1",
+    "asset-builder": "^1.0.1",
     "browser-sync": "^2.0.1",
     "del": "^1.1.1",
     "gulp": "^3.8.10",


### PR DESCRIPTION
Bumps asset-builder to 1.0.1

Closes https://github.com/roots/sage/issues/1351