### PR TITLE
Apply script_loader_src filter to jquery fallback

### DIFF
--- a/lib/assets.php
+++ b/lib/assets.php
@@ -130,12 +130,12 @@ function jquery_local_fallback($src, $handle = null) {
   static $add_jquery_fallback = false;
 
   if ($add_jquery_fallback) {
-    echo '<script>window.jQuery || document.write(\'<script src="' . get_template_directory_uri() . DIST_DIR . 'scripts/jquery.js"><\/script>\')</script>' . "\n";
+    echo '<script>window.jQuery || document.write(\'<script src="' . $add_jquery_fallback .'"><\/script>\')</script>' . "\n";
     $add_jquery_fallback = false;
   }
 
   if ($handle === 'jquery') {
-    $add_jquery_fallback = true;
+    $add_jquery_fallback = apply_filters('script_loader_src', asset_path('scripts/jquery.js'), 'jquery-fallback');
   }
 
   return $src;


### PR DESCRIPTION
This makes the fallback URL play nicely with Soil's relative URLs module.