### PR TITLE
change default columns to 3.

### DIFF
--- a/lib/gallery.php
+++ b/lib/gallery.php
@@ -43,7 +43,7 @@ function gallery($attr) {
     'itemtag'    => '',
     'icontag'    => '',
     'captiontag' => '',
-    'columns'    => 4,
+    'columns'    => 3,
     'size'       => 'thumbnail',
     'include'    => '',
     'exclude'    => '',
@@ -51,7 +51,7 @@ function gallery($attr) {
   ], $attr));
 
   $id = intval($id);
-  $columns = (12 % $columns == 0) ? $columns: 4;
+  $columns = (12 % $columns == 0) ? $columns: 3;
   $grid = sprintf('col-sm-%1$s col-lg-%1$s', 12/$columns);
 
   if ($order === 'RAND') {


### PR DESCRIPTION
Issue is if you set 3 in Gallery options it will output 4 columns in the frontend. The default WordPress column is 3 for gallery and if it's set to 3, it does not added any column attribute to the shortcode which cause the issue. Setting the default to 3 should fix the issue.