### PR TITLE
Update ConditionalTagCheck and usage docs

### DIFF
--- a/lib/conditional-tag-check.php
+++ b/lib/conditional-tag-check.php
@@ -26,12 +26,16 @@ class ConditionalTagCheck {
     }
   }
 
-  private function checkConditionalTag($conditional_tag) {
-    $conditional_arg = is_array($conditional_tag) ? $conditional_tag[1] : false;
-    $conditional_tag = $conditional_arg ? $conditional_tag[0] : $conditional_tag;
+  private function checkConditionalTag($conditional) {
+    if (is_array($conditional)) {
+      list($tag, $args) = $conditional;
+    } else {
+      $tag = $conditional;
+      $args = false;
+    }
 
-    if (function_exists($conditional_tag)) {
-      return $conditional_arg ? $conditional_tag($conditional_arg) : $conditional_tag();
+    if (function_exists($tag)) {
+      return $args ? $tag($args) : $tag();
     } else {
       return false;
     }

--- a/lib/config.php
+++ b/lib/config.php
@@ -39,26 +39,22 @@ function display_sidebar() {
        * Any of these conditional tags that return true won't show the sidebar.
        * You can also specify your own custom function as long as it returns a boolean.
        *
-       * To use a function that accepts arguments, use the following format:
-       *
-       * ['function_name', ['arg1', 'arg2']]
-       *
-       * Note: The second element must be an array even if there's only 1 argument.
+       * To use a function that accepts arguments, use an array instead of just the function name as a string.
        *
        * Examples:
        *
        * 'is_single'
        * 'is_archive'
-       * ['is_page', ['about-me']]
+       * ['is_page', 'about-me']
        * ['is_tax', ['flavor', 'mild']]
-       * ['is_page_template', ['about.php']]
-       * ['is_post_type_archive', [['foo', 'bar', 'baz']]]
+       * ['is_page_template', 'about.php']
+       * ['is_post_type_archive', ['foo', 'bar', 'baz']]
        *
        */
       [
         'is_404',
         'is_front_page',
-        ['is_page_template', ['template-custom.php']]
+        ['is_page_template', 'template-custom.php']
       ]
     );
 


### PR DESCRIPTION
When passing an argument to a function for ConditionalTagCheck, the argument should *not* always be an array. The function will be called wit the arguments as is and not modified. So if the function takes a string argument, keep it as a string. If it takes an array, use an array.