### PR TITLE
Run `build` if `bower.json` is changed

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -227,7 +227,7 @@ gulp.task('watch', function() {
   gulp.watch([path.source + 'scripts/**/*'], ['jshint', 'scripts']);
   gulp.watch([path.source + 'fonts/**/*'], ['fonts']);
   gulp.watch([path.source + 'images/**/*'], ['images']);
-  gulp.watch(['bower.json'], ['wiredep']);
+  gulp.watch(['bower.json'], ['build']);
   gulp.watch('**/*.php', function() {
     browserSync.reload();
   });


### PR DESCRIPTION
Been using Sage on a project. I've found it slightly frustrating that adding something via Bower seems to be added, but since only `wiredep` is run, nothing actually compiles.

It might take a few extra seconds, but changing the task from `wiredep` to `build` when `bower.json` is changed should re-compile everything and have your shiny new Bower package compiled correctly