### PR TITLE
Added more explicit instructions for BrowserSync.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,26 @@ You now have all the necessary dependencies to run the build process.
 * `gulp watch` — Compile assets when file changes are made
 * `gulp --production` — Compile assets for production (no source maps).
 
+### Using BrowserSync
+
 To use BrowserSync during `gulp watch` you need update `devUrl` at the bottom of `assets/manifest.json` to reflect your local development hostname.
+
+For example, if your local development URL is `http://project-name.dev` you would update the file to read:
+```json
+...
+  "config": {
+    "devUrl": "http://project-name.dev"
+  }
+...
+```
+If your local develoment URL looks like `http://localhost:8888/project-name/` you would update the file to read:
+```json
+...
+  "config": {
+    "devUrl": "http://localhost:8888/project-name/"
+  }
+...
+```
 
 ## Documentation
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -25,6 +25,6 @@
     }
   },
   "config": {
-    "devUrl": "example.dev"
+    "devUrl": "http://example.dev"
   }
 }


### PR DESCRIPTION
Hopefully we get less of these threads: https://discourse.roots.io/t/browser-sync-wordpress-and-mamp/3061/7