### PR TITLE
Changing SageNavWalker to NavWalker, using class directly in template

### DIFF
--- a/lib/nav.php
+++ b/lib/nav.php
@@ -15,7 +15,7 @@ use Roots\Sage\Utils;
  *   <li class="menu-home"><a href="/">Home</a></li>
  *   <li class="menu-sample-page"><a href="/sample-page/">Sample Page</a></li>
  */
-class SageNavWalker extends \Walker_Nav_Menu {
+class NavWalker extends \Walker_Nav_Menu {
   private $cpt; // Boolean, is current post a custom post type
   private $archive; // Stores the archive page for current URL
 

--- a/templates/header.php
+++ b/templates/header.php
@@ -1,4 +1,4 @@
-<?php use Roots\Sage\Nav; ?>
+<?php use Roots\Sage\Nav\NavWalker; ?>
 
 <header class="banner navbar navbar-default navbar-static-top" role="banner">
   <div class="container">
@@ -15,7 +15,7 @@
     <nav class="collapse navbar-collapse" role="navigation">
       <?php
       if (has_nav_menu('primary_navigation')) :
-        wp_nav_menu(['theme_location' => 'primary_navigation', 'walker' => new Nav\SageNavWalker(), 'menu_class' => 'nav navbar-nav']);
+        wp_nav_menu(['theme_location' => 'primary_navigation', 'walker' => new NavWalker(), 'menu_class' => 'nav navbar-nav']);
       endif;
       ?>
     </nav>


### PR DESCRIPTION
Cleaning this up slightly, `SageNavWalker` still had the old style namespacing. Also since it's a class, we can reference it directly in the template without the last namespace connected to it.