### PR TITLE
Run styles and scripts in sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 * Update to Bootstrap 3.3.4
+* Fix `gulp --production` race condition ([#1398](https://github.com/roots/sage/issues/1398))
 
 ### 8.1.0: March 13th, 2015
 * Move HTML5 Boilerplate's Google Analytics snippet to Soil ([#1382](https://github.com/roots/sage/issues/1382))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@ var browserSync = require('browser-sync');
 var gulp        = require('gulp');
 var lazypipe    = require('lazypipe');
 var merge       = require('merge-stream');
+var runSequence = require('run-sequence');
 
 // See https://github.com/austinpray/asset-builder
 var manifest = require('asset-builder')('./assets/manifest.json');
@@ -236,7 +237,12 @@ gulp.task('watch', function() {
 // ### Build
 // `gulp build` - Run all the build tasks but don't clean up beforehand.
 // Generally you should be running `gulp` instead of `gulp build`.
-gulp.task('build', ['styles', 'scripts', 'fonts', 'images']);
+gulp.task('build', function(callback) {
+  runSequence('styles',
+              'scripts',
+              ['fonts', 'images'],
+              callback);
+});
 
 // ### Wiredep
 // `gulp wiredep` - Automatically inject Less and Sass Bower dependencies. See

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "jshint-stylish": "^1.0.1",
     "lazypipe": "^0.2.2",
     "merge-stream": "^0.1.7",
+    "run-sequence": "^1.0.2",
     "traverse": "^0.6.6",
     "wiredep": "^2.2.2",
     "yargs": "^3.6.0"


### PR DESCRIPTION
Prevents potential race condition where styles and scripts write to the
manifest at the same time

fixes https://github.com/roots/sage/issues/1398

Updates changelog