### PR TITLE
Removes gulp-pleeease dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### HEAD
 * Update to Bootstrap 3.3.4
 * Fix `gulp --production` race condition ([#1398](https://github.com/roots/sage/issues/1398))
+* Remove pleeease dependency in favor of vanilla gulp-autoprefixer and gulp-minify-css ([#1402](https://github.com/roots/sage/issues/1402))
 
 ### 8.1.0: March 13th, 2015
 * Move HTML5 Boilerplate's Google Analytics snippet to Soil ([#1382](https://github.com/roots/sage/issues/1382))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,14 +81,13 @@ var cssTasks = function(filename) {
         }));
       })
       .pipe($.concat, filename)
-      .pipe($.pleeease, {
-        autoprefixer: {
-          browsers: [
-            'last 2 versions', 'ie 8', 'ie 9', 'android 2.3', 'android 4',
-            'opera 12'
-          ]
-        }
+      .pipe($.autoprefixer, {
+        browsers: [
+          'last 2 versions', 'ie 8', 'ie 9', 'android 2.3', 'android 4',
+          'opera 12'
+        ]
       })
+      .pipe($.minifyCss)
     .pipe(function() {
       return $.if(enabled.rev, $.rev());
     })

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "npm": ">=2.1.5"
   },
   "devDependencies": {
-    "pleeease": "3.2.0",
     "asset-builder": "^1.0.2",
     "browser-sync": "^2.4.0",
     "del": "^1.1.1",
     "gulp": "^3.8.11",
+    "gulp-autoprefixer": "^2.1.0",
     "gulp-changed": "^1.2.1",
     "gulp-concat": "^2.5.2",
     "gulp-flatten": "0.0.4",
@@ -40,7 +40,7 @@
     "gulp-jshint": "^1.9.4",
     "gulp-less": "^3.0.2",
     "gulp-load-plugins": "^0.9.0",
-    "gulp-pleeease": "^1.2.0",
+    "gulp-minify-css": "^1.0.0",
     "gulp-plumber": "^1.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-rev": "^3.0.1",


### PR DESCRIPTION
This gulp plugin was more trouble than it was worth.

ref https://github.com/roots/sage/issues/1386
ref https://discourse.roots.io/t/sourcemaps-no-longer-working-as-expected-with-sage-update/3022/1