### PR TITLE
Add support for asset-builder-cli

### DIFF
--- a/asset-builder.json
+++ b/asset-builder.json
@@ -1,0 +1,3 @@
+{
+  "manifest": "./assets/manifest.json"
+}


### PR DESCRIPTION
specify the manifest location here so CLI users do not have to type the `-m` or `--manifest` flag.

Simply:

`npm i -g asset-builder-cli@latest` and then run `assetbuilder` in theme root.