### PR TITLE
Switch from yargs to minimist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Remove `$content_width` ([#1417](https://github.com/roots/sage/issues/1417))
 * Lowercase `X-UA-Compatible` ([#1409](https://github.com/roots/sage/issues/1409))
 * Remove mention of Google Analytics from the config ([#1384](https://github.com/roots/sage/issues/1384))
+* Switch from [yargs](https://github.com/bcoe/yargs) to [minimist](https://github.com/substack/minimist)
 
 ### 8.1.1: March 31st, 2015
 * Remove pleeease dependency in favor of vanilla gulp-autoprefixer and gulp-minify-css ([#1402](https://github.com/roots/sage/issues/1402))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 // ## Globals
 /*global $:true*/
 var $           = require('gulp-load-plugins')();
-var argv        = require('yargs').argv;
+var argv        = require('minimist')(process.argv.slice(2));
 var browserSync = require('browser-sync');
 var gulp        = require('gulp');
 var lazypipe    = require('lazypipe');

--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
     "jshint-stylish": "^1.0.1",
     "lazypipe": "^0.2.2",
     "merge-stream": "^0.1.7",
+    "minimist": "^1.1.1",
     "run-sequence": "^1.0.2",
     "traverse": "^0.6.6",
-    "wiredep": "^2.2.2",
-    "yargs": "^3.6.0"
+    "wiredep": "^2.2.2"
   }
 }


### PR DESCRIPTION
For our simple usecase we do not need the extra functionality of yargs.
This removes 4 dependencies from our dependency graph.

https://github.com/bcoe/yargs
https://github.com/substack/minimist