### PR TITLE
Remove hardcoded feed link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Remove hardcoded feed link ([#1426](https://github.com/roots/sage/issues/1426))
 * Move jQuery CDN feature to Soil ([#1422](https://github.com/roots/sage/issues/1422))
 * Bump `gulp-load-plugins` to 0.10.0 ([#1419](https://github.com/roots/sage/issues/1419))
 * Switch from [yargs](https://github.com/bcoe/yargs) to [minimist](https://github.com/substack/minimist) ([#1418](https://github.com/roots/sage/issues/1418))

--- a/templates/head.php
+++ b/templates/head.php
@@ -4,6 +4,5 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="alternate" type="application/rss+xml" title="<?= get_bloginfo('name'); ?> Feed" href="<?= esc_url(get_feed_link()); ?>">
     <?php wp_head(); ?>
   </head>


### PR DESCRIPTION
moving forward, use `add_theme_support('automatic-feed-links');` in a site functionality plugin to add feed links

`add_theme_support('automatic-feed-links');` wasn't ever used in the starter theme since it adds additional (unnecessary, imo) feed links, such as for comments. related: https://github.com/roots/soil/issues/68