### PR TITLE
Limit file patterns in gulp watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -217,6 +217,7 @@ gulp.task('clean', require('del').bind(null, [path.dist]));
 // See: http://www.browsersync.io
 gulp.task('watch', function() {
   browserSync({
+    files: [path.dist, '{lib,templates}/**/*.php', '*.php'],
     proxy: config.devUrl,
     snippetOptions: {
       whitelist: ['/wp-admin/admin-ajax.php'],
@@ -228,9 +229,6 @@ gulp.task('watch', function() {
   gulp.watch([path.source + 'fonts/**/*'], ['fonts']);
   gulp.watch([path.source + 'images/**/*'], ['images']);
   gulp.watch(['bower.json', 'assets/manifest.json'], ['build']);
-  gulp.watch('**/*.php', function() {
-    browserSync.reload();
-  });
 });
 
 // ### Build


### PR DESCRIPTION
`gulp watch` was taking anywhere from 3 - 14 **minutes** (depending on disk activity, I assume) to start for me. This brings it down to a much more sane ~150ms.

The problem seems to be that `gulp watch` was walking all directories looking for PHP files, node_modules in particular. This limits it to `./`, `./lib/`, and `./templates/` directories.