### PR TITLE
Trigger `get_footer` action before including footer template

### DIFF
--- a/base.php
+++ b/base.php
@@ -29,6 +29,7 @@ use Roots\Sage\Wrapper;
       </div><!-- /.content -->
     </div><!-- /.wrap -->
     <?php
+      do_action('get_footer');
       get_template_part('templates/footer');
       wp_footer();
     ?>


### PR DESCRIPTION
Since `get_footer()` is not used, `get_footer` template hooks needs to be triggered just like `get_header` does.