### PR TITLE
Remove gulp-load-plugins dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,12 +1,24 @@
 // ## Globals
-/*global $:true*/
-var $           = require('gulp-load-plugins')();
-var argv        = require('minimist')(process.argv.slice(2));
-var browserSync = require('browser-sync');
-var gulp        = require('gulp');
-var lazypipe    = require('lazypipe');
-var merge       = require('merge-stream');
-var runSequence = require('run-sequence');
+var argv         = require('minimist')(process.argv.slice(2));
+var autoprefixer = require('gulp-autoprefixer');
+var browserSync  = require('browser-sync');
+var changed      = require('gulp-changed');
+var concat       = require('gulp-concat');
+var flatten      = require('gulp-flatten');
+var gulp         = require('gulp');
+var gulpif       = require('gulp-if');
+var imagemin     = require('gulp-imagemin');
+var jshint       = require('gulp-jshint');
+var lazypipe     = require('lazypipe');
+var less         = require('gulp-less');
+var merge        = require('merge-stream');
+var minifyCss    = require('gulp-minify-css');
+var plumber      = require('gulp-plumber');
+var rev          = require('gulp-rev');
+var runSequence  = require('run-sequence');
+var sass         = require('gulp-sass');
+var sourcemaps   = require('gulp-sourcemaps');
+var uglify       = require('gulp-uglify');
 
 // See https://github.com/austinpray/asset-builder
 var manifest = require('asset-builder')('./assets/manifest.json');
@@ -64,35 +76,39 @@ var revManifest = path.dist + 'assets.json';
 var cssTasks = function(filename) {
   return lazypipe()
     .pipe(function() {
-      return $.if(!enabled.failStyleTask, $.plumber());
+      return gulpif(!enabled.failStyleTask, plumber());
     })
     .pipe(function() {
-      return $.if(enabled.maps, $.sourcemaps.init());
-    })
-      .pipe(function() {
-        return $.if('*.less', $.less());
-      })
-      .pipe(function() {
-        return $.if('*.scss', $.sass({
-          outputStyle: 'nested', // libsass doesn't support expanded yet
-          precision: 10,
-          includePaths: ['.'],
-          errLogToConsole: !enabled.failStyleTask
-        }));
-      })
-      .pipe($.concat, filename)
-      .pipe($.autoprefixer, {
-        browsers: [
-          'last 2 versions', 'ie 8', 'ie 9', 'android 2.3', 'android 4',
-          'opera 12'
-        ]
-      })
-      .pipe($.minifyCss)
-    .pipe(function() {
-      return $.if(enabled.rev, $.rev());
+      return gulpif(enabled.maps, sourcemaps.init());
     })
     .pipe(function() {
-      return $.if(enabled.maps, $.sourcemaps.write('.'));
+      return gulpif('*.less', less());
+    })
+    .pipe(function() {
+      return gulpif('*.scss', sass({
+        outputStyle: 'nested', // libsass doesn't support expanded yet
+        precision: 10,
+        includePaths: ['.'],
+        errLogToConsole: !enabled.failStyleTask
+      }));
+    })
+    .pipe(concat, filename)
+    .pipe(autoprefixer, {
+      browsers: [
+        'last 2 versions',
+        'ie 8',
+        'ie 9',
+        'android 2.3',
+        'android 4',
+        'opera 12'
+      ]
+    })
+  .pipe(minifyCss)
+    .pipe(function() {
+      return gulpif(enabled.rev, rev());
+    })
+    .pipe(function() {
+      return gulpif(enabled.maps, sourcemaps.write('.'));
     })();
 };
 
@@ -106,15 +122,15 @@ var cssTasks = function(filename) {
 var jsTasks = function(filename) {
   return lazypipe()
     .pipe(function() {
-      return $.if(enabled.maps, $.sourcemaps.init());
+      return gulpif(enabled.maps, sourcemaps.init());
     })
-    .pipe($.concat, filename)
-    .pipe($.uglify)
+    .pipe(concat, filename)
+    .pipe(uglify)
     .pipe(function() {
-      return $.if(enabled.rev, $.rev());
+      return gulpif(enabled.rev, rev());
     })
     .pipe(function() {
-      return $.if(enabled.maps, $.sourcemaps.write('.'));
+      return gulpif(enabled.maps, sourcemaps.write('.'));
     })();
 };
 
@@ -125,9 +141,9 @@ var writeToManifest = function(directory) {
   return lazypipe()
     .pipe(gulp.dest, path.dist + directory)
     .pipe(function() {
-      return $.if('**/*.{js,css}', browserSync.reload({stream:true}));
+      return gulpif('**/*.{js,css}', browserSync.reload({stream:true}));
     })
-    .pipe($.rev.manifest, revManifest, {
+    .pipe(rev.manifest, revManifest, {
       base: path.dist,
       merge: true
     })
@@ -178,7 +194,7 @@ gulp.task('scripts', ['jshint'], function() {
 // structure. See: https://github.com/armed/gulp-flatten
 gulp.task('fonts', function() {
   return gulp.src(globs.fonts)
-    .pipe($.flatten())
+    .pipe(flatten())
     .pipe(gulp.dest(path.dist + 'fonts'));
 });
 
@@ -186,7 +202,7 @@ gulp.task('fonts', function() {
 // `gulp images` - Run lossless compression on all the images.
 gulp.task('images', function() {
   return gulp.src(globs.images)
-    .pipe($.imagemin({
+    .pipe(imagemin({
       progressive: true,
       interlaced: true,
       svgoPlugins: [{removeUnknownsAndDefaults: false}]
@@ -200,9 +216,9 @@ gulp.task('jshint', function() {
   return gulp.src([
     'bower.json', 'gulpfile.js'
   ].concat(project.js))
-    .pipe($.jshint())
-    .pipe($.jshint.reporter('jshint-stylish'))
-    .pipe($.jshint.reporter('fail'));
+    .pipe(jshint())
+    .pipe(jshint.reporter('jshint-stylish'))
+    .pipe(jshint.reporter('fail'));
 });
 
 // ### Clean
@@ -248,8 +264,8 @@ gulp.task('wiredep', function() {
   var wiredep = require('wiredep').stream;
   return gulp.src(project.css)
     .pipe(wiredep())
-    .pipe($.changed(path.source + 'styles', {
-      hasChanged: $.changed.compareSha1Digest
+    .pipe(changed(path.source + 'styles', {
+      hasChanged: changed.compareSha1Digest
     }))
     .pipe(gulp.dest(path.source + 'styles'));
 });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "gulp-imagemin": "^2.2.1",
     "gulp-jshint": "^1.9.4",
     "gulp-less": "^3.0.2",
-    "gulp-load-plugins": "^0.10.0",
     "gulp-minify-css": "^1.0.0",
     "gulp-plumber": "^1.0.0",
     "gulp-rename": "^1.2.0",


### PR DESCRIPTION
Simplify the gulpfile by removing gulp-load-plugins dependency. Some
whitespace cleanup and formatting to match normal NPM conventions.