### PR TITLE
Allow revved production files on dev environment

### DIFF
--- a/lib/assets.php
+++ b/lib/assets.php
@@ -58,7 +58,7 @@ function asset_path($filename) {
     $manifest = new JsonManifest($manifest_path);
   }
 
-  if (WP_ENV !== 'development' && array_key_exists($file, $manifest->get())) {
+  if (array_key_exists($file, $manifest->get())) {
     return $dist_path . $directory . $manifest->get()[$file];
   } else {
     return $dist_path . $directory . $file;


### PR DESCRIPTION
This change allows you to run `gulp --production` on your development environment and have the page load properly. `gulp --production` on dev breaks neat features of `gulp watch` like browsersync and so forth. However it does permit you to test the `--production` output locally before deployment.