### PR TITLE
update BrowserSync

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -196,7 +196,8 @@ gulp.task('scripts', ['jshint'], function() {
 gulp.task('fonts', function() {
   return gulp.src(globs.fonts)
     .pipe(flatten())
-    .pipe(gulp.dest(path.dist + 'fonts'));
+    .pipe(gulp.dest(path.dist + 'fonts'))
+    .pipe(browserSync.stream());
 });
 
 // ### Images
@@ -208,7 +209,8 @@ gulp.task('images', function() {
       interlaced: true,
       svgoPlugins: [{removeUnknownsAndDefaults: false}]
     }))
-    .pipe(gulp.dest(path.dist + 'images'));
+    .pipe(gulp.dest(path.dist + 'images'))
+    .pipe(browserSync.stream());
 });
 
 // ### JSHint
@@ -234,7 +236,7 @@ gulp.task('clean', require('del').bind(null, [path.dist]));
 // See: http://www.browsersync.io
 gulp.task('watch', function() {
   browserSync.init({
-    files: [path.dist, '{lib,templates}/**/*.php', '*.php'],
+    files: ['{lib,templates}/**/*.php', '*.php'],
     proxy: config.devUrl,
     snippetOptions: {
       whitelist: ['/wp-admin/admin-ajax.php'],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 // ## Globals
 var argv         = require('minimist')(process.argv.slice(2));
 var autoprefixer = require('gulp-autoprefixer');
-var browserSync  = require('browser-sync');
+var browserSync  = require('browser-sync').create();
 var changed      = require('gulp-changed');
 var concat       = require('gulp-concat');
 var flatten      = require('gulp-flatten');
@@ -143,9 +143,7 @@ var jsTasks = function(filename) {
 var writeToManifest = function(directory) {
   return lazypipe()
     .pipe(gulp.dest, path.dist + directory)
-    .pipe(function() {
-      return gulpif('**/*.{js,css}', browserSync.reload({stream:true}));
-    })
+    .pipe(browserSync.stream, {match: '**/*.{js,css}'})
     .pipe(rev.manifest, revManifest, {
       base: path.dist,
       merge: true
@@ -235,7 +233,7 @@ gulp.task('clean', require('del').bind(null, [path.dist]));
 // build step for that asset and inject the changes into the page.
 // See: http://www.browsersync.io
 gulp.task('watch', function() {
-  browserSync({
+  browserSync.init({
     files: [path.dist, '{lib,templates}/**/*.php', '*.php'],
     proxy: config.devUrl,
     snippetOptions: {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "asset-builder": "^1.0.2",
-    "browser-sync": "2.5.0",
+    "browser-sync": "^2.7.1",
     "del": "^1.1.1",
     "gulp": "^3.8.11",
     "gulp-autoprefixer": "^2.1.0",


### PR DESCRIPTION
This PR switches to BrowserSync's recommended "[post 2.0.0 syntax](http://www.browsersync.io/docs/api)" and uses the cleaner [`stream`](http://www.browsersync.io/docs/api/#api-stream) method for reloading. The stream method offers glob filtering, so we are able to simplify the reload pipe in `writeToManifest` a bit. 

This is compatible with #1448.