### PR TITLE
Remove jQuery CDN info

### DIFF
--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -8,10 +8,6 @@
  * .noConflict()
  * The routing is enclosed within an anonymous function so that you can
  * always reference jQuery with $, even when in .noConflict() mode.
- *
- * Google CDN, Latest jQuery
- * To use the default WordPress version of jQuery, go to lib/config.php and
- * remove or comment out: add_theme_support('jquery-cdn');
  * ======================================================================== */
 
 (function($) {


### PR DESCRIPTION
Now that the CDN option is in soil, there's no need for this information to be in the file (and it was outdated).