### PR TITLE
add missing navbar-nav class

### DIFF
--- a/templates/header.php
+++ b/templates/header.php
@@ -4,7 +4,7 @@
     <nav role="navigation">
       <?php
       if (has_nav_menu('primary_navigation')) :
-        wp_nav_menu(['theme_location' => 'primary_navigation', 'menu_class' => 'nav']);
+        wp_nav_menu(['theme_location' => 'primary_navigation', 'menu_class' => 'nav navbar-nav']);
       endif;
       ?>
     </nav>


### PR DESCRIPTION
When the navwalker was removed, it looks like the navbar-nav class got removed as well.

That class is still necessary for proper rendering of a Boostrap navbar.