### PR TITLE
change hooks to anonymous functions

### DIFF
--- a/lib/assets.php
+++ b/lib/assets.php
@@ -65,7 +65,7 @@ function asset_path($filename) {
   }
 }
 
-function assets() {
+add_action('wp_enqueue_scripts', function() {
   wp_enqueue_style('sage_css', asset_path('styles/main.css'), false, null);
 
   if (is_single() && comments_open() && get_option('thread_comments')) {
@@ -74,5 +74,4 @@ function assets() {
 
   wp_enqueue_script('modernizr', asset_path('scripts/modernizr.js'), [], null, true);
   wp_enqueue_script('sage_js', asset_path('scripts/main.js'), ['jquery'], null, true);
-}
-add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\assets', 100);
+});

--- a/lib/assets.php
+++ b/lib/assets.php
@@ -65,7 +65,7 @@ function asset_path($filename) {
   }
 }
 
-add_action('wp_enqueue_scripts', function() {
+add_action('wp_enqueue_scripts', function () {
   wp_enqueue_style('sage_css', asset_path('styles/main.css'), false, null);
 
   if (is_single() && comments_open() && get_option('thread_comments')) {

--- a/lib/extras.php
+++ b/lib/extras.php
@@ -7,7 +7,7 @@ use Roots\Sage\Config;
 /**
  * Add <body> classes
  */
-function body_class($classes) {
+add_filter('body_class', function ($classes) {
   // Add page slug if it doesn't exist
   if (is_single() || is_page() && !is_front_page()) {
     if (!in_array(basename(get_permalink()), $classes)) {
@@ -21,13 +21,11 @@ function body_class($classes) {
   }
 
   return $classes;
-}
-add_filter('body_class', __NAMESPACE__ . '\\body_class');
+});
 
 /**
  * Clean up the_excerpt()
  */
-function excerpt_more() {
+add_filter('excerpt_more', function() {
   return ' &hellip; <a href="' . get_permalink() . '">' . __('Continued', 'sage') . '</a>';
-}
-add_filter('excerpt_more', __NAMESPACE__ . '\\excerpt_more');
+});

--- a/lib/extras.php
+++ b/lib/extras.php
@@ -26,6 +26,6 @@ add_filter('body_class', function ($classes) {
 /**
  * Clean up the_excerpt()
  */
-add_filter('excerpt_more', function() {
+add_filter('excerpt_more', function () {
   return ' &hellip; <a href="' . get_permalink() . '">' . __('Continued', 'sage') . '</a>';
 });

--- a/lib/init.php
+++ b/lib/init.php
@@ -7,7 +7,7 @@ use Roots\Sage\Assets;
 /**
  * Theme setup
  */
-add_action('after_setup_theme', function() {
+add_action('after_setup_theme', function () {
   // Make theme available for translation
   // Community translations can be found at https://github.com/roots/sage-translations
   load_theme_textdomain('sage', get_template_directory() . '/lang');
@@ -43,7 +43,7 @@ add_action('after_setup_theme', function() {
 /**
  * Register sidebars
  */
-add_action('widgets_init', function() {
+add_action('widgets_init', function () {
   register_sidebar([
     'name'          => __('Primary', 'sage'),
     'id'            => 'sidebar-primary',

--- a/lib/init.php
+++ b/lib/init.php
@@ -7,7 +7,7 @@ use Roots\Sage\Assets;
 /**
  * Theme setup
  */
-function setup() {
+add_action('after_setup_theme', function() {
   // Make theme available for translation
   // Community translations can be found at https://github.com/roots/sage-translations
   load_theme_textdomain('sage', get_template_directory() . '/lang');
@@ -38,13 +38,12 @@ function setup() {
 
   // Tell the TinyMCE editor to use a custom stylesheet
   add_editor_style(Assets\asset_path('styles/editor-style.css'));
-}
-add_action('after_setup_theme', __NAMESPACE__ . '\\setup');
+});
 
 /**
  * Register sidebars
  */
-function widgets_init() {
+add_action('widgets_init', function() {
   register_sidebar([
     'name'          => __('Primary', 'sage'),
     'id'            => 'sidebar-primary',
@@ -62,5 +61,4 @@ function widgets_init() {
     'before_title'  => '<h3>',
     'after_title'   => '</h3>'
   ]);
-}
-add_action('widgets_init', __NAMESPACE__ . '\\widgets_init');
+});

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -5,7 +5,7 @@ namespace Roots\Sage\Utils;
 /**
  * Tell WordPress to use searchform.php from the templates/ directory
  */
-add_filter('get_search_form', function() {
+add_filter('get_search_form', function () {
   $form = '';
   locate_template('/templates/searchform.php', true, false);
   return $form;

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -5,9 +5,8 @@ namespace Roots\Sage\Utils;
 /**
  * Tell WordPress to use searchform.php from the templates/ directory
  */
-function get_search_form() {
+add_filter('get_search_form', function() {
   $form = '';
   locate_template('/templates/searchform.php', true, false);
   return $form;
-}
-add_filter('get_search_form', __NAMESPACE__ . '\\get_search_form');
+});


### PR DESCRIPTION
It's unnecessary overhead to create functions that will only ever be used in hooks. This cleans up the hooks that could be changed to anonymous functions.

It didn't fit this PR, but I also recommend moving the utils.php hook to extras.php or something. It's now an unused namespace and doesn't really fit there, in my opinion. I'd imagine general purpose, utility functions to live there.