### PR TITLE
Keep SVG element IDs during gulp images task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -207,7 +207,7 @@ gulp.task('images', function() {
     .pipe(imagemin({
       progressive: true,
       interlaced: true,
-      svgoPlugins: [{removeUnknownsAndDefaults: false}]
+      svgoPlugins: [{removeUnknownsAndDefaults: false}, {cleanupIDs: false}]
     }))
     .pipe(gulp.dest(path.dist + 'images'))
     .pipe(browserSync.stream());


### PR DESCRIPTION
Includes a cleanupIDs set to false option within the gulp images task in order to preserve the ID's set for internal SVG elements.