### PR TITLE
Modify wrapper to conditionally show sidebar-*.php templates for custom post types

### DIFF
--- a/base.php
+++ b/base.php
@@ -25,7 +25,7 @@ use Roots\Sage\Wrapper;
         </main><!-- /.main -->
         <?php if (Config\display_sidebar()) : ?>
           <aside class="sidebar" role="complementary">
-            <?php include Wrapper\sidebar_path(); ?>
+            <?php include Wrapper\sidebar_path(Config\custom_sidebar()); ?>
           </aside><!-- /.sidebar -->
         <?php endif; ?>
       </div><!-- /.content -->

--- a/lib/config.php
+++ b/lib/config.php
@@ -63,3 +63,21 @@ function display_sidebar() {
 
   return $display;
 }
+
+/**
+ * Display custom sidebars for these post types
+ */
+function custom_sidebar() {
+  $cpt_sidebars = [
+    /**
+     * Any post type slug entered as an array value here will display a custom sidebar template.
+     * eg.
+     * 'gizmos'
+     * would display `templates/sidebar-gizmos.php`
+     */
+  ];
+  if(in_array(get_post_type(), $cpt_sidebars)) {
+    return '-'.get_post_type();
+  } 
+}
+

--- a/lib/wrapper.php
+++ b/lib/wrapper.php
@@ -13,8 +13,8 @@ function template_path() {
   return SageWrapping::$main_template;
 }
 
-function sidebar_path() {
-  return new SageWrapping('templates/sidebar.php');
+function sidebar_path($name) {
+  return new SageWrapping('templates/sidebar'.$name.'.php');
 }
 
 class SageWrapping {


### PR DESCRIPTION
Not sure if this is a particularly elegant way to do it, but it's helped me so thought I'd share! 

Being able to specify different sidebars for different post types cuts down on the need for duplicate `base-*.php` files. Obviously these sidebars have to be declared in `widgets_init()` too with this solution, but still.... an idea :-)