### PR TITLE
Adjust comments on ConditionalTagCheck to match actual functionality.

### DIFF
--- a/lib/conditional-tag-check.php
+++ b/lib/conditional-tag-check.php
@@ -4,7 +4,7 @@ namespace Roots\Sage;
 
 /**
  * Utility class which takes an array of conditional tags (or any function which returns a boolean)
- * and returns `true` if *any* of them are `true`, and `false` otherwise.
+ * and returns `false` if *any* of them are `true`, and `true` otherwise.
  *
  * @param array list of conditional tags (http://codex.wordpress.org/Conditional_Tags)
  *        or custom function which returns a boolean


### PR DESCRIPTION
The check returns false, if any of it's tags are true, not vise versa.

To be perfectly honest this behaviour seems opposite of what I'd expect (should return true if any of them are true) but it would be a breaking change, so for now just update the comments to match.