### PR TITLE
Allow `debugger` statements in development JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 * Add search templates ([#1459](https://github.com/roots/sage/issues/1459))
+* Allow `debugger` statements in development JavaScript ([#1487](https://github.com/roots/sage/issues/1487))
 
 ### 8.2.1: May 7th, 2015
 * Update BrowserSync ([#1457](https://github.com/roots/sage/issues/1457))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,7 +57,11 @@ var enabled = {
   // Disable source maps when `--production`
   maps: !argv.production,
   // Fail styles task on error when `--production`
-  failStyleTask: argv.production
+  failStyleTask: argv.production,
+  // Fail due to JSHint warnings only when `--production`
+  failJSHint: argv.production,
+  // Strip debug statments from javascript when `--production`
+  stripJSDebug: argv.production
 };
 
 // Path to the compiled assets manifest in the dist directory
@@ -128,7 +132,11 @@ var jsTasks = function(filename) {
       return gulpif(enabled.maps, sourcemaps.init());
     })
     .pipe(concat, filename)
-    .pipe(uglify)
+    .pipe(uglify, {
+      compress: {
+        'drop_debugger': enabled.stripJSDebug
+      }
+    })
     .pipe(function() {
       return gulpif(enabled.rev, rev());
     })
@@ -221,7 +229,7 @@ gulp.task('jshint', function() {
   ].concat(project.js))
     .pipe(jshint())
     .pipe(jshint.reporter('jshint-stylish'))
-    .pipe(jshint.reporter('fail'));
+    .pipe(gulpif(enabled.failJSHint, jshint.reporter('fail')));
 });
 
 // ### Clean


### PR DESCRIPTION
fixes https://github.com/roots/sage/issues/1480

cc @aaemnnosttv 