### PR TITLE
Support for svg in asset pipeline

### DIFF
--- a/assets/svg/content-svg.php
+++ b/assets/svg/content-svg.php
@@ -1,0 +1,3 @@
+<div style="height: 0; width: 0; position: absolute; visibility: hidden">
+  <!-- inject:svg --><!-- endinject -->
+</div>

--- a/base.php
+++ b/base.php
@@ -16,6 +16,7 @@ use Roots\Sage\Wrapper;
     <![endif]-->
     <?php
       do_action('get_header');
+      get_template_part('templates/content-svg.php');
       get_template_part('templates/header');
     ?>
     <div class="wrap container" role="document">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -219,11 +219,11 @@ gulp.task('images', function() {
 
 // ### Svg
 // `gulp svg` - Minifies, injects and create fallbacks all svg files
-gulp.task('svg', function () {
+gulp.task('svg', function() {
   var svgPath = path.source + 'svg/*.svg';
   var svg = gulp.src(svgPath)
     .pipe(svgMin())
-    .pipe(svgStore({ inlineSvg: true }));
+    .pipe(svgStore({inlineSvg: true}));
 
   function fileContents (filePath, file) {
     return file.contents.toString();
@@ -234,10 +234,9 @@ gulp.task('svg', function () {
     .pipe(gulp.dest(path.source + 'svg/fallback'));
 
   return gulp.src(path.source + 'svg/content-svg.php')
-    .pipe(inject(svg, { transform: fileContents }))
+    .pipe(inject(svg, {transform: fileContents}))
     .pipe(gulp.dest('templates'));
 });
-
 
 // ### JSHint
 // `gulp jshint` - Lints configuration JSON and project JS.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "gulp-flatten": "0.0.4",
     "gulp-if": "^1.2.5",
     "gulp-imagemin": "^2.2.1",
+    "gulp-inject": "^1.3.0",
     "gulp-jshint": "^1.9.4",
     "gulp-less": "^3.0.2",
     "gulp-minify-css": "^1.0.0",
@@ -45,6 +46,9 @@
     "gulp-rev": "^3.0.1",
     "gulp-sass": "^2.0.0",
     "gulp-sourcemaps": "^1.5.1",
+    "gulp-svg2png": "^0.3.0",
+    "gulp-svgmin": "^1.1.2",
+    "gulp-svgstore": "^5.0.2",
     "gulp-uglify": "^1.1.0",
     "imagemin-pngcrush": "^4.0.0",
     "jshint-stylish": "^1.0.1",
@@ -54,5 +58,8 @@
     "run-sequence": "^1.0.2",
     "traverse": "^0.6.6",
     "wiredep": "^2.2.2"
+  },
+  "dependencies": {
+    "gulp-inject": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,8 +58,5 @@
     "run-sequence": "^1.0.2",
     "traverse": "^0.6.6",
     "wiredep": "^2.2.2"
-  },
-  "dependencies": {
-    "gulp-inject": "^1.3.0"
   }
 }


### PR DESCRIPTION
As discussed at https://discourse.roots.io/t/adding-svg-support-to-the-asset-pipeline

The approach of this solution is largely inspired of this css-tricks article https://css-tricks.com/svg-sprites-use-better-icon-fonts/

### Overview:
- Svg files are stored in assets/svg
- Those files are minified and injected to a file called templates/content-svg.php
- content-svg.php gets included in base.php
- For better browser support a png fallback is created for every svg file

### Usage:
The svg files are converted to symbol elements in content-svg.php. Every symbol get the id from the original file name, ie menu.svg becomes <symbol id="menu" ...
To reference a symbol you simply use:


```html
<svg>
  <use xlink:href="#"></use>
</svg>
```

In order for this to work, the content-svg.php file have to be included. I have included it in the base.php file.

### Improvements:
- I didn't really get the hang of the globs variables in the Gulpfile. I guess you could store svg paths in there for better consistency.
- Better automated workflow for adding png fallbacks

