### PR TITLE
Fix source map paths

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -111,7 +111,9 @@ var cssTasks = function(filename) {
       return gulpif(enabled.rev, rev());
     })
     .pipe(function() {
-      return gulpif(enabled.maps, sourcemaps.write('.'));
+      return gulpif(enabled.maps, sourcemaps.write('.', {
+        sourceRoot: 'assets/styles/'
+      }));
     })();
 };
 
@@ -133,7 +135,9 @@ var jsTasks = function(filename) {
       return gulpif(enabled.rev, rev());
     })
     .pipe(function() {
-      return gulpif(enabled.maps, sourcemaps.write('.'));
+      return gulpif(enabled.maps, sourcemaps.write('.', {
+        sourceRoot: 'assets/scripts/'
+      }));
     })();
 };
 


### PR DESCRIPTION
This sets the gulp-sourcemaps `sourceRoot` option, now pointing to the right locations of the source maps. Since it was not set, it was pointing to the default [`/source/`](https://github.com/floridoo/gulp-sourcemaps/blob/master/index.js#L191) folder, which is not the right folder.