### PR TITLE
Removing PHP short tags as per WP theme review standards

### DIFF
--- a/templates/entry-meta.php
+++ b/templates/entry-meta.php
@@ -1,2 +1,2 @@
-<time class="updated" datetime="<?= get_the_time('c'); ?>"><?= get_the_date(); ?></time>
-<p class="byline author vcard"><?= __('By', 'sage'); ?> <a href="<?= get_author_posts_url(get_the_author_meta('ID')); ?>" rel="author" class="fn"><?= get_the_author(); ?></a></p>
+<time class="updated" datetime="<?php echo get_the_time('c'); ?>"><?php echo get_the_date(); ?></time>
+<p class="byline author vcard"><?php echo __('By', 'sage'); ?> <a href="<?php echo get_author_posts_url(get_the_author_meta('ID')); ?>" rel="author" class="fn"><?php echo get_the_author(); ?></a></p>

--- a/templates/header.php
+++ b/templates/header.php
@@ -1,6 +1,6 @@
 <header class="banner" role="banner">
   <div class="container">
-    <a class="brand" href="<?= esc_url(home_url('/')); ?>"><?php bloginfo('name'); ?></a>
+    <a class="brand" href="<?php echo esc_url(home_url('/')); ?>"><?php bloginfo('name'); ?></a>
     <nav role="navigation">
       <?php
       if (has_nav_menu('primary_navigation')) :

--- a/templates/page-header.php
+++ b/templates/page-header.php
@@ -1,5 +1,5 @@
 <?php use Roots\Sage\Titles; ?>
 
 <div class="page-header">
-  <h1><?= Titles\title(); ?></h1>
+  <h1><?php echo Titles\title(); ?></h1>
 </div>

--- a/templates/searchform.php
+++ b/templates/searchform.php
@@ -1,7 +1,7 @@
-<form role="search" method="get" class="search-form form-inline" action="<?= esc_url(home_url('/')); ?>">
+<form role="search" method="get" class="search-form form-inline" action="<?php echo esc_url(home_url('/')); ?>">
   <label class="sr-only"><?php _e('Search for:', 'sage'); ?></label>
   <div class="input-group">
-    <input type="search" value="<?= get_search_query(); ?>" name="s" class="search-field form-control" placeholder="<?php _e('Search', 'sage'); ?> <?php bloginfo('name'); ?>" required>
+    <input type="search" value="<?php echo get_search_query(); ?>" name="s" class="search-field form-control" placeholder="<?php _e('Search', 'sage'); ?> <?php bloginfo('name'); ?>" required>
     <span class="input-group-btn">
       <button type="submit" class="search-submit btn btn-default"><?php _e('Search', 'sage'); ?></button>
     </span>


### PR DESCRIPTION
PHP short tags, such as ``<?=$variable?>``, are disabled by many web hosts and therefore discouraged according to the WP [theme review standards](https://make.wordpress.org/themes/handbook/review/required/theme-check-plugin/)

Removing all instances of short tags being used in favor of more verbose alternative ``<? echo $variable ?>``