### PR TITLE
Update jscs validateJSDoc to jsDoc rule

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -86,7 +86,7 @@
   "disallowSpacesInsideObjectBrackets": "all",
   "disallowSpacesInsideArrayBrackets": "all",
   "disallowSpacesInsideParentheses": true,
-  "validateJSDoc": {
+  "jsDoc": {
     "checkParamNames": true,
     "requireParamTypes": true
   },


### PR DESCRIPTION
Replaced depricated validateJSDoc rule with jsDoc rule: http://jscs.info/rule/jsDoc.html