### PR TITLE
Add `--fast` flag to gulp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### HEAD
 * Add search templates ([#1459](https://github.com/roots/sage/issues/1459))
 * Allow `debugger` statements in development JavaScript ([#1487](https://github.com/roots/sage/issues/1487))
+* Add `--fast` flag to gulpfile.js ([#1459](https://github.com/roots/sage/pull/1523))
 
 ### 8.2.1: May 7th, 2015
 * Update BrowserSync ([#1457](https://github.com/roots/sage/issues/1457))

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You now have all the necessary dependencies to run the build process.
 * `gulp` — Compile and optimize the files in your assets directory
 * `gulp watch` — Compile assets when file changes are made
 * `gulp --production` — Compile assets for production (no source maps).
+* Optionally add the `--fast` flag to skip minification.
 
 ### Using BrowserSync
 


### PR DESCRIPTION
Allows users to skip minification by using `--fast` flag.

* `gulp --fast`
* `gulp watch --fast`

PS-
I'm not very good at naming branches.