### PR TITLE
fix timezone offset in ISO 8601 date in byline

### DIFF
--- a/templates/entry-meta.php
+++ b/templates/entry-meta.php
@@ -1,2 +1,2 @@
-<time class="updated" datetime="<?= get_the_time('c'); ?>"><?= get_the_date(); ?></time>
+<time class="updated" datetime="<?= get_post_time('c', true); ?>"><?= get_the_date(); ?></time>
 <p class="byline author vcard"><?= __('By', 'sage'); ?> <a href="<?= get_author_posts_url(get_the_author_meta('ID')); ?>" rel="author" class="fn"><?= get_the_author(); ?></a></p>


### PR DESCRIPTION
get_the_time('c') returns the local time in ISO 8601 format, but does
not fetch the related GMT timezone offset. This actually renders the incorrect time, as the timezone offset is always +00:00.

Google News, in particular, uses this time to show when an article was published. In our case it was always 7 hours too early because we are in GMT -7

get_post_time('c', true) is the correct function here, using the true parameter for GMT.