### PR TITLE
Add keepSpecialComments: 0 to minifyCss process …

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,6 +110,7 @@ var cssTasks = function(filename) {
     .pipe(minifyCss, {
       advanced: false,
       rebase: false
+      keepSpecialComments: 0
     })
     .pipe(function() {
       return gulpif(enabled.rev, rev());

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,7 +109,7 @@ var cssTasks = function(filename) {
     })
     .pipe(minifyCss, {
       advanced: false,
-      rebase: false
+      rebase: false,
       keepSpecialComments: 0
     })
     .pipe(function() {


### PR DESCRIPTION
Opps, missing comma... This removes all comments from the resulting compiled SASS and concat/minified CSS.  Solves an issue where the /*! style comments in bootstrap break the minification process.