### PR TITLE
Add compatibility with WooCommerce Multilingual plugin

### DIFF
--- a/lib/wrapper.php
+++ b/lib/wrapper.php
@@ -61,4 +61,4 @@ class SageWrapping {
     return new SageWrapping();
   }
 }
-add_filter('template_include', [__NAMESPACE__ . '\\SageWrapping', 'wrap'], 99);
+add_filter('template_include', [__NAMESPACE__ . '\\SageWrapping', 'wrap'], 109);


### PR DESCRIPTION
I experienced a conflict between Sage and a WPML and WooCommerce combination, where a translated product archive (specificly product_cat taxonomy page) wouldn't be wrapped in the base template. Just the template file contents would be executed without the master/base template. This could be solved by changeing the priority of the template_include filter for the wrapper to >100. I'm not sure if this is WooCommerce specific or if this would be the case for any translated taxonomy when using WPML.