### PR TITLE
Use WP core's HTML5 gallery markup

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -34,7 +34,7 @@ function setup() {
 
   // Add HTML5 markup for captions
   // http://codex.wordpress.org/Function_Reference/add_theme_support#HTML5
-  add_theme_support('html5', ['caption', 'comment-form', 'comment-list']);
+  add_theme_support('html5', ['caption', 'comment-form', 'comment-list', 'gallery']);
 
   // Tell the TinyMCE editor to use a custom stylesheet
   add_editor_style(Assets\asset_path('styles/editor-style.css'));


### PR DESCRIPTION
gallery was removed in #1421, but this simple addition enables the html5 gallery markup from wp core

(uses `<figure>` instead of a definition list)