### PR TITLE
Remove references to WP_ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,6 @@ Install the [Soil](https://github.com/roots/soil) plugin to enable additional fe
 
 Clone the git repo - `git clone https://github.com/roots/sage.git` and then rename the directory to the name of your theme or website.
 
-If you don't use [Bedrock](https://github.com/roots/bedrock), you'll need to add the following to your `wp-config.php` on your development installation:
-
-```php
-define('WP_ENV', 'development');
-```
-
 ## Configuration
 
 Edit `lib/config.php` to enable or disable theme features

--- a/lib/config.php
+++ b/lib/config.php
@@ -16,12 +16,6 @@ add_theme_support('soil-jquery-cdn');       // Enable to load jQuery from the Go
 /**
  * Configuration values
  */
-if (!defined('WP_ENV')) {
-  // Fallback if WP_ENV isn't defined in your WordPress config
-  // Used in lib/assets.php to check for 'development' or 'production'
-  define('WP_ENV', 'production');
-}
-
 if (!defined('DIST_DIR')) {
   // Path to the build directory for front-end assets
   define('DIST_DIR', '/dist/');


### PR DESCRIPTION
WP_ENV is no longer required. previous dependencies on WP_ENV were removed in #1456 and #1382.