### PR TITLE
Setup organization

### DIFF
--- a/lib/assets.php
+++ b/lib/assets.php
@@ -3,9 +3,8 @@
 namespace Roots\Sage\Assets;
 
 /**
- * Scripts and stylesheets
+ * Get paths for assets
  */
-
 class JsonManifest {
   private $manifest;
 
@@ -57,14 +56,3 @@ function asset_path($filename) {
     return $dist_path . $directory . $file;
   }
 }
-
-function assets() {
-  wp_enqueue_style('sage/css', asset_path('styles/main.css'), false, null);
-
-  if (is_single() && comments_open() && get_option('thread_comments')) {
-    wp_enqueue_script('comment-reply');
-  }
-
-  wp_enqueue_script('sage/js', asset_path('scripts/main.js'), ['jquery'], null, true);
-}
-add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\assets', 100);

--- a/lib/assets.php
+++ b/lib/assets.php
@@ -41,13 +41,13 @@ class JsonManifest {
 }
 
 function asset_path($filename) {
-  $dist_path = get_template_directory_uri() . DIST_DIR;
+  $dist_path = get_template_directory_uri() . '/dist/';
   $directory = dirname($filename) . '/';
   $file = basename($filename);
   static $manifest;
 
   if (empty($manifest)) {
-    $manifest_path = get_template_directory() . DIST_DIR . 'assets.json';
+    $manifest_path = get_template_directory() . '/dist/' . 'assets.json';
     $manifest = new JsonManifest($manifest_path);
   }
 

--- a/lib/setup.php
+++ b/lib/setup.php
@@ -14,14 +14,6 @@ add_theme_support('soil-nice-search');      // Enable nice search from Soil
 add_theme_support('soil-jquery-cdn');       // Enable to load jQuery from the Google CDN
 
 /**
- * Configuration values
- */
-if (!defined('DIST_DIR')) {
-  // Path to the build directory for front-end assets
-  define('DIST_DIR', '/dist/');
-}
-
-/**
  * Theme setup
  */
 function setup() {

--- a/lib/setup.php
+++ b/lib/setup.php
@@ -89,3 +89,17 @@ function display_sidebar() {
 
   return apply_filters('sage/display_sidebar', $display);
 }
+
+/**
+ * Theme assets
+ */
+function assets() {
+  wp_enqueue_style('sage/css', Assets\asset_path('styles/main.css'), false, null);
+
+  if (is_single() && comments_open() && get_option('thread_comments')) {
+    wp_enqueue_script('comment-reply');
+  }
+
+  wp_enqueue_script('sage/js', Assets\asset_path('scripts/main.js'), ['jquery'], null, true);
+}
+add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\assets', 100);

--- a/lib/setup.php
+++ b/lib/setup.php
@@ -5,18 +5,17 @@ namespace Roots\Sage\Setup;
 use Roots\Sage\Assets;
 
 /**
- * Enable theme features
- */
-add_theme_support('soil-clean-up');         // Enable clean up from Soil
-add_theme_support('soil-nav-walker');       // Enable cleaner nav walker from Soil
-add_theme_support('soil-relative-urls');    // Enable relative URLs from Soil
-add_theme_support('soil-nice-search');      // Enable nice search from Soil
-add_theme_support('soil-jquery-cdn');       // Enable to load jQuery from the Google CDN
-
-/**
  * Theme setup
  */
 function setup() {
+  // Enable features from Soil when plugin is activated
+  // https://roots.io/plugins/soil/
+  add_theme_support('soil-clean-up');
+  add_theme_support('soil-nav-walker');
+  add_theme_support('soil-nice-search');
+  add_theme_support('soil-jquery-cdn');
+  add_theme_support('soil-relative-urls');
+
   // Make theme available for translation
   // Community translations can be found at https://github.com/roots/sage-translations
   load_theme_textdomain('sage', get_template_directory() . '/lang');
@@ -31,21 +30,21 @@ function setup() {
     'primary_navigation' => __('Primary Navigation', 'sage')
   ]);
 
-  // Add post thumbnails
+  // Enable post thumbnails
   // http://codex.wordpress.org/Post_Thumbnails
   // http://codex.wordpress.org/Function_Reference/set_post_thumbnail_size
   // http://codex.wordpress.org/Function_Reference/add_image_size
   add_theme_support('post-thumbnails');
 
-  // Add post formats
+  // Enable post formats
   // http://codex.wordpress.org/Post_Formats
   add_theme_support('post-formats', ['aside', 'gallery', 'link', 'image', 'quote', 'video', 'audio']);
 
-  // Add HTML5 markup for captions
+  // Enable HTML5 markup support
   // http://codex.wordpress.org/Function_Reference/add_theme_support#HTML5
   add_theme_support('html5', ['caption', 'comment-form', 'comment-list', 'gallery', 'search-form']);
 
-  // Tell the TinyMCE editor to use a custom stylesheet
+  // Custom stylesheet for visual editor
   add_editor_style(Assets\asset_path('styles/editor-style.css'));
 }
 add_action('after_setup_theme', __NAMESPACE__ . '\\setup');


### PR DESCRIPTION
Related: #1555, #1556 

* Remove `DIST_DIR` constant introduced in #1366 / #1352. You can choose to implement this on your own moving forward as it's not something we recommend changing.

* Move Soil theme support into setup function — dependent on https://github.com/roots/soil/pull/120 (will tag a new Soil version)

* Move CSS/JS enqueues to setup.php