### PR TITLE
Simplify/speed up editor style process.

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -12,11 +12,6 @@
       ],
       "main": true
     },
-    "editor-style.css": {
-      "files": [
-        "styles/editor-style.scss"
-      ]
-    },
     "jquery.js": {
       "bower": ["jquery"]
     }

--- a/assets/styles/layouts/_tinymce.scss
+++ b/assets/styles/layouts/_tinymce.scss
@@ -1,5 +1,3 @@
-@import "main";
-
-body {
+body#tinymce {
   margin: 12px !important;
 }

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -16,3 +16,4 @@
 @import "layouts/_footer";
 @import "layouts/_pages";
 @import "layouts/_posts";
+@import "layouts/_tinymce";

--- a/lib/setup.php
+++ b/lib/setup.php
@@ -45,7 +45,7 @@ function setup() {
   add_theme_support('html5', ['caption', 'comment-form', 'comment-list', 'gallery', 'search-form']);
 
   // Custom stylesheet for visual editor
-  add_editor_style(Assets\asset_path('styles/editor-style.css'));
+  add_editor_style(Assets\asset_path('styles/main.css'));
 }
 add_action('after_setup_theme', __NAMESPACE__ . '\\setup');
 


### PR DESCRIPTION
This is in response to https://github.com/roots/sage/issues/1552.

After playing around, I think the best solution is just to add a `_tinymce.scss` file in `/assets/layouts/` where we target the tinymce editor and can put conditional styles in there, and then just reference the main.css file in the wp editor.

This cuts styles compiling time of the default repo in half (roughly) because we're no longer creating 2 files, and no longer referencing a large scss file and injecting it into another one.