### PR TITLE
add auto height to .alignnone to prevent vertical stretch of image

### DIFF
--- a/assets/styles/components/_wp-classes.scss
+++ b/assets/styles/components/_wp-classes.scss
@@ -6,6 +6,7 @@
   margin-left: 0;
   margin-right: 0;
   max-width: 100%;
+  height: auto;
 }
 .aligncenter {
   display: block;


### PR DESCRIPTION
I came across an issue with images being stretched in posts when using the class `.alignnone`. If the image's width is greater than that of the container's, the image will shrink to fit the container but the original height is still being declared in the img tag with `height=""`. As a result, the image is being stretched vertically. Adding `height: auto;` to `.alignnone` will resize the image vertically to maintain it's original aspect ratio.