### PR TITLE
wp-classes alignment (right, left, center) height set to auto for proper scaling

### DIFF
--- a/assets/styles/components/_wp-classes.scss
+++ b/assets/styles/components/_wp-classes.scss
@@ -11,10 +11,12 @@
 .aligncenter {
   display: block;
   margin: ($line-height-computed / 2) auto;
+  height: auto;
 }
 .alignleft,
 .alignright {
   margin-bottom: ($line-height-computed / 2);
+  height: auto;
 }
 @media (min-width: $screen-sm-min) {
   // Only float if not on an extra small device


### PR DESCRIPTION
Extending on https://github.com/roots/sage/pull/1565, `.alignleft`, `.alignright` and `.aligncenter` also skew vertically when the image width is wider than the container. Adding `height: auto` to these classes will override the `img` tag's height property and properly scale the image across different breakpoints.