### PR TITLE
Drop support for older browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Drop support for older browsers ([#1571](https://github.com/roots/sage/pull/1571))
 * Remove extraneous no-js ([#1562](https://github.com/roots/sage/pull/1562))
 * Simplify/speed up editor style process ([#1560](https://github.com/roots/sage/pull/1560))
 

--- a/base.php
+++ b/base.php
@@ -9,7 +9,7 @@ use Roots\Sage\Wrapper;
 <html <?php language_attributes(); ?>>
   <?php get_template_part('templates/head'); ?>
   <body <?php body_class(); ?>>
-    <!--[if lt IE 9]>
+    <!--[if IE]>
       <div class="alert alert-warning">
         <?php _e('You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.', 'sage'); ?>
       </div>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -100,9 +100,6 @@ var cssTasks = function(filename) {
     .pipe(autoprefixer, {
       browsers: [
         'last 2 versions',
-        'ie 8',
-        'ie 9',
-        'android 2.3',
         'android 4',
         'opera 12'
       ]


### PR DESCRIPTION
Dropped support for IE 8, IE 9, and Android 2.3.

Outdated browser warning is displayed for IE 8 and IE 9 users.