### PR TITLE
Add gulp-stylus, add to gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@ var rev          = require('gulp-rev');
 var runSequence  = require('run-sequence');
 var sass         = require('gulp-sass');
 var sourcemaps   = require('gulp-sourcemaps');
+var stylus       = require('gulp-stylus');
 var uglify       = require('gulp-uglify');
 
 // See https://github.com/austinpray/asset-builder
@@ -95,6 +96,9 @@ var cssTasks = function(filename) {
         includePaths: ['.'],
         errLogToConsole: !enabled.failStyleTask
       }));
+    })
+    .pipe(function() {
+      return gulpif('*.styl', stylus());
     })
     .pipe(concat, filename)
     .pipe(autoprefixer, {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "gulp-rev": "^6.0.0",
     "gulp-sass": "^2.0.1",
     "gulp-sourcemaps": "^1.5.2",
+    "gulp-stylus": "^2.1.0",
     "gulp-uglify": "^1.2.0",
     "imagemin-pngcrush": "^4.1.0",
     "jshint-stylish": "^2.0.1",
@@ -54,8 +55,5 @@
     "run-sequence": "^1.1.2",
     "traverse": "^0.6.6",
     "wiredep": "^2.2.2"
-  },
-  "dependencies": {
-    "gulp-stylus": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
     "run-sequence": "^1.1.2",
     "traverse": "^0.6.6",
     "wiredep": "^2.2.2"
+  },
+  "dependencies": {
+    "gulp-stylus": "^2.1.0"
   }
 }


### PR DESCRIPTION
Stylus has greatly increased in popularity over the past couple of years—in 2012, it had about [6% market share](https://css-tricks.com/poll-results-popularity-of-css-preprocessors/) in terms of CSS preprocessing, Sass had 41% market share, and LESS had 51% market share.

Assuming repo "stars" are indicative of usage, [Stylus](https://github.com/stylus/stylus/) now has about 24% market share, [Sass](https://github.com/sass/sass) has 26% market share, and [LESS](https://github.com/less/less.js) has 50% market share.

It seems to me that if Sass is supported in Sage, we should also support Stylus.  Thoughts?