### PR TITLE
Remove unnecessary underscore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Remove unnecessary underscore ([#1577](https://github.com/roots/sage/pull/1577))
 * Drop support for older browsers ([#1571](https://github.com/roots/sage/pull/1571))
 * Add support for theme customizer ([#1573](https://github.com/roots/sage/pull/1573))
 * Remove extraneous no-js ([#1562](https://github.com/roots/sage/pull/1562))

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -5,15 +5,15 @@
 @import "../../bower_components/bootstrap-sass/assets/stylesheets/_bootstrap.scss";
 // endbower
 
-@import "common/_global";
-@import "components/_buttons";
-@import "components/_comments";
-@import "components/_forms";
-@import "components/_grid";
-@import "components/_wp-classes";
-@import "layouts/_header";
-@import "layouts/_sidebar";
-@import "layouts/_footer";
-@import "layouts/_pages";
-@import "layouts/_posts";
-@import "layouts/_tinymce";
+@import "common/global";
+@import "components/buttons";
+@import "components/comments";
+@import "components/forms";
+@import "components/grid";
+@import "components/wp-classes";
+@import "layouts/header";
+@import "layouts/sidebar";
+@import "layouts/footer";
+@import "layouts/pages";
+@import "layouts/posts";
+@import "layouts/tinymce";


### PR DESCRIPTION
Sass doesn't need the underscore that's present in the filename when doing an import