### PR TITLE
add monitorctrlc for easy gulp watch termination

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ var runSequence  = require('run-sequence');
 var sass         = require('gulp-sass');
 var sourcemaps   = require('gulp-sourcemaps');
 var uglify       = require('gulp-uglify');
+var monitorCtrlC = require('monitorctrlc');
 
 // See https://github.com/austinpray/asset-builder
 var manifest = require('asset-builder')('./assets/manifest.json');
@@ -244,6 +245,7 @@ gulp.task('clean', require('del').bind(null, [path.dist]));
 // build step for that asset and inject the changes into the page.
 // See: http://www.browsersync.io
 gulp.task('watch', function() {
+  monitorCtrlC();
   browserSync.init({
     files: ['{lib,templates}/**/*.php', '*.php'],
     proxy: config.devUrl,

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lazypipe": "^1.0.1",
     "merge-stream": "^1.0.0",
     "minimist": "^1.1.3",
+    "monitorctrlc": "^1.0.1",
     "run-sequence": "^1.1.2",
     "traverse": "^0.6.6",
     "wiredep": "^2.2.2"


### PR DESCRIPTION
This will fix very annoying problem with terminating `gulp watch` command from command line. At least for me (on OS X Yosemite with iTerm2) pressing `Ctrl+C` has no effect on `gulp watch` process.