### PR TITLE
Added `stability` flag to example Composer install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you're already [using Composer to manage WordPress](https://roots.io/using-co
 The example below assumes you're using Bedrock. If you're not, simply change the target path accordingly.
 
 ```sh
-composer create-project roots/sage web/app/themes/your-theme-name-here
+composer create-project roots/sage web/app/themes/your-theme-name-here --stability dev
 ```
 
 Then activate the theme via [wp-cli](http://wp-cli.org/commands/theme/activate/).


### PR DESCRIPTION
Composer's `stability` flag defaults to `stable` (see https://getcomposer.org/doc/03-cli.md#create-project) which causes the command `composer create-project roots/sage web/app/themes/your-theme-name-here` to fail with the error:
```
[InvalidArgumentException]
Could not find package roots/sage with stability stable.
```
Using `composer create-project roots/sage web/app/themes/your-theme-name-here --stability dev` resolves this.