### PR TITLE
Disable JS variable renaming when sourcemaps are enabled

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,6 +132,7 @@ var jsTasks = function(filename) {
     })
     .pipe(concat, filename)
     .pipe(uglify, {
+      mangle: !enabled.maps,
       compress: {
         'drop_debugger': enabled.stripJSDebug
       }


### PR DESCRIPTION
Disable variable renaming when JS sourcemaps are enabled in order to ease JS debugging with browser debugger (e.g. Chrome Console).