### PR TITLE
gitignore composer vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 bower_components
 node_modules
 npm-debug.log
+vendor


### PR DESCRIPTION
`composer create-project` (see 6a6ff885360a96b70d9e883f24ab73435762dbc4) adds vendor directory which we do not want to have in version control.

composer.json and composer.lock should probably also be ignored – at the moment they are only covered by Bedrock's gitignore file.