### PR TITLE
Fix autoloader load order issue when including Sage 9 via composer.json in Bedrock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,7 @@
   "autoload": {
     "psr-4": {
       "Roots\\Sage\\": "src/lib/Sage/"
-    },
-    "files": [
-      "src/helpers.php",
-      "src/setup.php",
-      "src/filters.php",
-      "src/admin.php"
-    ]
+    }
   },
   "require": {
     "php": ">=5.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bae0265fe64b728b3ad0fd3ab2ca2df0",
+    "hash": "7382dc6bb77190896306e1eb58b6589c",
     "content-hash": "75ad99c892e1d82404c58fe3bd989585",
     "packages": [
         {

--- a/functions.php
+++ b/functions.php
@@ -24,6 +24,31 @@ add_action('after_switch_theme', function () {
 });
 
 /**
+ * Sage includes
+ *
+ * The $sage_includes array determines the code library included in your theme.
+ * Add or remove files to the array as needed. Supports child theme overrides.
+ *
+ * Please note that missing files will produce a fatal error.
+ *
+ * @link https://github.com/roots/sage/pull/1042
+ */
+$sage_includes = [
+    'src/helpers.php',    // Helper functions
+    'src/setup.php',      // Theme setup
+    'src/filters.php',    // Filters
+    'src/admin.php'       // Admin
+];
+
+foreach ($sage_includes as $file) {
+    if (!$filepath = locate_template($file)) {
+        trigger_error(sprintf(__('Error locating %s for inclusion', 'sage'), $file), E_USER_ERROR);
+    }
+    require_once $filepath;
+}
+unset($file, $filepath);
+
+/**
  * Require composer autoloader
  */
 require_once __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
The Composer Autoloader has issues with the "files" directive in composer.json when Sage 9 is included as a package in a Bedrock project via the root composer.json.

After diagnosing, I don't see a way the "files" directive can be used in the Sage composer.json and not cause issues with load order.  The root composer package (in Bedrock) will see the files directive in the package and automatically attempt to load prior to WordPress. 

psr-4 autoloading for Roots\Sage should still work fine in this scenario since these are lazy-loaded.

I've moved the offending 4 files from autoloader back into functions.php the way they were in Sage 8.  I'm not sure if there is a more clever way to do this, but it fixes the issue.