### PR TITLE
Feature/manage virtualhost with dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DEV_URL=virtualhost_url

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ bower_components
 node_modules
 npm-debug.log
 vendor
+
+# Dotenv
+.env
+.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -101,23 +101,15 @@ You now have all the necessary dependencies to run the build process.
 
 ### Using BrowserSync
 
-To use BrowserSync during `gulp watch` you need to update `devUrl` at the bottom of `assets/manifest.json` to reflect your local development hostname.
+To use BrowserSync during `gulp watch` you need to update copy the `.env.example` file to a new file and name it `.env`, and set `DEV_URL` to reflect your local development hostname.
 
 For example, if your local development URL is `http://project-name.dev` you would update the file to read:
-```json
-...
-  "config": {
-    "devUrl": "http://project-name.dev"
-  }
-...
+```
+DEV_URL=project-name.dev
 ```
 If your local development URL looks like `http://localhost:8888/project-name/` you would update the file to read:
-```json
-...
-  "config": {
-    "devUrl": "http://localhost:8888/project-name/"
-  }
-...
+```
+DEV_URL=localhost:8888/project-name/
 ```
 
 ## Documentation

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -20,8 +20,5 @@
     "jquery.js": {
       "bower": ["jquery"]
     }
-  },
-  "config": {
-    "devUrl": "http://example.dev"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ var runSequence  = require('run-sequence');
 var sass         = require('gulp-sass');
 var sourcemaps   = require('gulp-sourcemaps');
 var uglify       = require('gulp-uglify');
+var dotenv       = require('dotenv').config();
 
 // See https://github.com/austinpray/asset-builder
 var manifest = require('asset-builder')('./assets/manifest.json');
@@ -239,13 +240,13 @@ gulp.task('clean', require('del').bind(null, [path.dist]));
 // ### Watch
 // `gulp watch` - Use BrowserSync to proxy your dev server and synchronize code
 // changes across devices. Specify the hostname of your dev server at
-// `manifest.config.devUrl`. When a modification is made to an asset, run the
+// `.env`. When a modification is made to an asset, run the
 // build step for that asset and inject the changes into the page.
 // See: http://www.browsersync.io
 gulp.task('watch', function() {
   browserSync.init({
     files: ['{lib,templates}/**/*.php', '*.php'],
-    proxy: config.devUrl,
+    proxy: process.env.DEV_URL,
     snippetOptions: {
       whitelist: ['/wp-admin/admin-ajax.php'],
       blacklist: ['/wp-admin/**']

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "minimist": "^1.1.3",
     "run-sequence": "^1.1.2",
     "traverse": "^0.6.6",
-    "wiredep": "^2.2.2"
+    "wiredep": "^2.2.2",
+    "dotenv": "^2.0.0"
   }
 }


### PR DESCRIPTION
**The problem:**
If I'm using Sage with a team of developers, all of us have to set the same virtualhost's name in each of our machines to match the `assets/manifest.json` file. 
If I, for example, set my virtualhost url to project-name.dev, and my team mate sets his to projectname.local and I pull the changes he made in  `assets/manifest.json`, my browsersync wont work because now I have the wrong virtualhost url.

**My solution:**
I propose the use of [dotenv](https://www.npmjs.com/package/dotenv) to specify the virtualhost url in each project. 
This way, only a file called .env.example will be passed in git, and then each team member copies that file to another named .env (which will be ignored by git) and set his own virtualhost url.
The usage of dotenv will of course also enable other local variables to can be used with the browsersync plugin, such as port and host options.

This solution has been tested, and I'm also currently using it in my own front-end boilerplate project.