### PR TITLE
Update use of deprecated .brand to use .navbar-brand instead

### DIFF
--- a/assets/scripts/customizer.js
+++ b/assets/scripts/customizer.js
@@ -2,7 +2,7 @@
   // Site title
   wp.customize('blogname', function(value) {
     value.bind(function(to) {
-      $('.brand').text(to);
+      $('.navbar-brand').text(to);
     });
   });
 })(jQuery);

--- a/templates/partials/header.php
+++ b/templates/partials/header.php
@@ -1,6 +1,6 @@
 <header class="banner">
   <div class="container">
-    <a class="brand" href="<?= esc_url(home_url('/')); ?>"><?php bloginfo('name'); ?></a>
+    <a class="navbar-brand" href="<?= esc_url(home_url('/')); ?>"><?php bloginfo('name'); ?></a>
     <nav class="nav-primary">
       <?php
       if (has_nav_menu('primary_navigation')) :


### PR DESCRIPTION
Bootstrap replaced .brand with .navbar-brand in this 2013 commit:
https://github.com/twbs/bootstrap/commit/023568fe3dba59b7f5c12ac610e02fd8bd6c772f