### PR TITLE
Create prototype of GitHub Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,61 @@
+## Submit a feature request or bug report
+
+- [ ] This is a feature request
+- [ ] This is a bug report
+- [ ] This request isn't a duplicate of an [existing issue](https://github.com/roots/sage/issues)
+- [ ] I've read the [docs](https://roots.io/sage/docs) and [NPM Debugging Guidelines post](https://discourse.roots.io/t/npm-debugging-guidelines-failed-npm-install-bower-install-or-gulp-build-read-this/3060) and followed them (if applicable)
+- [ ] This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/c/sage) forums
+
+Replace any `X` with your information.
+
+---
+
+**What is the current behavior?**
+
+X
+
+
+**What is the expected or desired behavior?**
+
+X
+
+---
+
+## Bug report
+
+(delete this section if not applicable)
+
+**Please provide steps to reproduce, including full log output:**
+
+X
+
+**Please describe your local environment:**
+
+WordPress version: X
+
+OS: X
+
+NPM/Node version: X
+
+**Where did the bug happen? Development or remote servers?**
+
+X
+
+
+**Is there a related [Discourse](https://discourse.roots.io/) thread or were any utilized (please link them)?**
+
+X
+
+---
+
+## Feature Request
+
+(delete this section if not applicable)
+
+**Please provide use cases for changing the current behavior:**
+
+X
+
+**Other relevant information:**
+
+X


### PR DESCRIPTION
Just trying to get the ball rolling on https://github.com/roots/sage/issues/1619

Inspired by several other GitHub Issue Templates, including [Yoast SEO](https://github.com/Yoast/wordpress-seo/blob/master/ISSUE_TEMPLATE.md).

Open to suggestions on this one. We probably wouldn't want to ask too much up front (such as making them list their WordPress plugins), but asking for OS and NPM/Node versions can be quite handy when troubleshooting.

Also looking for some good examples of Pull Request Templates, but I think the Roots team is going to be more qualified to set those up :smile: 