### PR TITLE
Add `npm prune` to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
   - node -v && npm -v
   - npm rebuild
   - travis_retry npm install
+  - npm prune
   - composer install -o --prefer-dist --no-interaction
 
 script:


### PR DESCRIPTION
> Via https://docs.npmjs.com/cli/prune
> > This command removes "extraneous" packages. If a package name is provided, then only packages matching one of the supplied names are removed.
> >
> > Extraneous packages are packages that are not listed on the parent package's dependencies list.

The reason for adding this is to go hand in hand with the Travis CI caching implemented a while ago, if you don't run `npm prune` periodically then older packages will not be removed from the cache and the cache will continue to grow in size.

I suspect if you compare the Travis CI cache size between master and this PR, this PR will be significantly smaller. (You could also inspect the cache with Travis CI CLI I think)

https://travis-ci.org/roots/sage/caches