### PR TITLE
add gulp-notify message on css or javascript error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@ var imagemin     = require('gulp-imagemin');
 var jshint       = require('gulp-jshint');
 var lazypipe     = require('lazypipe');
 var less         = require('gulp-less');
+var notify       = require("gulp-notify");
 var merge        = require('merge-stream');
 var cssNano      = require('gulp-cssnano');
 var plumber      = require('gulp-plumber');
@@ -80,7 +81,9 @@ var revManifest = path.dist + 'assets.json';
 var cssTasks = function(filename) {
   return lazypipe()
     .pipe(function() {
-      return gulpif(!enabled.failStyleTask, plumber());
+      return gulpif(!enabled.failStyleTask, plumber({
+				errorHandler: notify.onError("<%= error.message %>")
+			}));
     })
     .pipe(function() {
       return gulpif(enabled.maps, sourcemaps.init());
@@ -126,6 +129,11 @@ var cssTasks = function(filename) {
 // ```
 var jsTasks = function(filename) {
   return lazypipe()
+    .pipe(function () {
+      return gulpif(!enabled.failJSHint, plumber({
+        errorHandler: notify.onError("<%= error.message %>")
+      }));
+    })
     .pipe(function() {
       return gulpif(enabled.maps, sourcemaps.init());
     })

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "gulp-imagemin": "^2.3.0",
     "gulp-jshint": "^1.11.2",
     "gulp-less": "^3.0.3",
+    "gulp-notify": "^2.2.0",
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-rev": "^6.0.0",


### PR DESCRIPTION
In addition to the error message in the console, shows a notify-error. This is especially useful for those who do not have the console active at all times, as you will instantly be notified if something went wrong. 

![image](https://cloud.githubusercontent.com/assets/9006167/15966188/54de287a-2f22-11e6-940d-1ff3bd58b305.png)
