### PR TITLE
Remove unnecessary string concat

### DIFF
--- a/lib/assets.php
+++ b/lib/assets.php
@@ -46,7 +46,7 @@ function asset_path($filename) {
   static $manifest;
 
   if (empty($manifest)) {
-    $manifest_path = get_template_directory() . '/dist/' . 'assets.json';
+    $manifest_path = get_template_directory() . '/dist/assets.json';
     $manifest = new JsonManifest($manifest_path);
   }
 


### PR DESCRIPTION
String concat is not required here.

Reduce complexity! Improve speed! :) This also makes tools like PHPCS happy.

See da514346 for the origins of this double-string concat.