### PR TITLE
Updated to align with the Bootstrap 4 docs

### DIFF
--- a/templates/partials/head.php
+++ b/templates/partials/head.php
@@ -1,6 +1,6 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <?php wp_head(); ?>
 </head>


### PR DESCRIPTION
Fixes a [viewport bug](https://developer.apple.com/library/ios/releasenotes/General/WhatsNewInSafari/Articles/Safari_9_0.html#//apple_ref/doc/uid/TP40014305-CH9-SW36) in Safari 9.0