### PR TITLE
Remove path.extname() check

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,12 +44,10 @@ var assetsPluginProcessOutput = function (assets) {
 
   for (name in assets) {
     if (assets.hasOwnProperty(name)) {
-      if (path.extname(assets[name]) === '') {
-        for (ext in assets[name]) {
-          if (assets[name].hasOwnProperty(ext)) {
-            filename = name + '.' + ext;
-            results[filename] = path.basename(assets[name][ext]);
-          }
+      for (ext in assets[name]) {
+        if (assets[name].hasOwnProperty(ext)) {
+          filename = name + '.' + ext;
+          results[filename] = path.basename(assets[name][ext]);
         }
       }
     }


### PR DESCRIPTION
Remove path.extname() check to fix build:production task.

Currently path.extname() is being supplied an object when it expects a string, resulting in a fatal error during production builds.

Removal is the cleanest solution as it's an unnecessary check, assets[name] will always be an object.