### PR TITLE
Set devUrl from Bedrock's .env (if it exists)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,6 +31,10 @@ var path = manifest.paths;
 // `config` - Store arbitrary configuration values here.
 var config = manifest.config || {};
 
+// Use the URL defined in Bedrock's .env (if it exists)
+require('dotenv').config({silent: true, path: '../../../../.env'});
+config.devUrl = process.env.WP_HOME || config.devUrl;
+
 // `globs` - These ultimately end up in their respective `gulp.src`.
 // - `globs.js` - Array of asset-builder JS dependency objects. Example:
 //   ```

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "asset-builder": "^1.1.0",
     "browser-sync": "^2.8.2",
     "del": "^1.2.1",
+    "dotenv": "^2.0.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^2.3.1",
     "gulp-changed": "^1.3.0",


### PR DESCRIPTION
If Bedrock's `.env` file exists, we read it and set `config.devUrl` to the `WP_HOME` value from it. Otherwise, we continue as normal (using the value from `manifest.json`).

This will allow a seamless integration of Bedrock and Sage without compromising the flexibility of using Sage without Bedrock.

This is similar to #1640 but much simpler and is focused solely on using Sage with Bedrock (a common scenario, I assume).