### PR TITLE
Fix path to stylesheet in add_editor_style

### DIFF
--- a/src/setup.php
+++ b/src/setup.php
@@ -62,7 +62,7 @@ add_action('after_setup_theme', function () {
      * Use main stylesheet for visual editor
      * @see assets/styles/layouts/_tinymce.scss
      */
-    add_editor_style(asset_path('main.css'));
+    add_editor_style(asset_path('styles/main.css'));
 });
 
 /**


### PR DESCRIPTION
String passed to asset_path needs to contain the directory name, otherwise it 404s on the post/page admin screen.