### PR TITLE
Set dynamically aboslute public path on 'npm run watch'; fix http/htt…

### DIFF
--- a/assets/config.json
+++ b/assets/config.json
@@ -2,6 +2,7 @@
   "context": "assets",
   "entry": {
     "main": [
+      "./scripts/util/public-path.js",
       "./scripts/main.js",
       "./styles/main.scss"
     ],
@@ -13,6 +14,5 @@
     "path": "dist",
     "publicPath": "/app/themes/sage/dist/"
   },
-  "devUrl": "http://example.dev",
-  "devPort": 3000
+  "devUrl": "http://example.dev"
 }

--- a/assets/scripts/util/public-path.js
+++ b/assets/scripts/util/public-path.js
@@ -1,0 +1,8 @@
+/* globals WEBPACK_PUBLIC_PATH */
+
+// Dynamically set absolute public path from current protocol and host
+if (WEBPACK_PUBLIC_PATH !== false) {
+  /* eslint-disable no-undef */
+  __webpack_public_path__ = location.protocol + '//' + location.host + WEBPACK_PUBLIC_PATH;
+  /*eslint-enable no-undef*/
+}

--- a/watch.js
+++ b/watch.js
@@ -9,15 +9,9 @@ var webpackConfig = require('./webpack.config'),
     config = require('./assets/config');
 
 // Internal variables
-var host = 'http://localhost',
-    port = config.devPort || '3000',
-    compiler;
-
-webpackConfig.output.publicPath = host + ':' + port + config.output.publicPath;
-compiler = webpack(webpackConfig);
+var compiler = webpack(webpackConfig);
 
 browserSync.init({
-  port: port,
   proxy: {
     target: config.devUrl,
     middleware: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -193,7 +193,7 @@ webpackConfig = {
       'window.Tether': 'tether'
     }),
     new webpack.DefinePlugin({
-      WEBPACK_PUBLIC_PATH: (argv.watch === true) ? JSON.stringify(config.output.publicPath) : false
+      WEBPACK_PUBLIC_PATH: (argv.watch === true) ? JSON.stringify(path.join(config.publicPath, dist)) : false
     })
   ],
   postcss: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -176,6 +176,9 @@ webpackConfig = {
       'window.jQuery': 'jquery',
       'Tether': 'tether',
       'window.Tether': 'tether'
+    }),
+    new webpack.DefinePlugin({
+      WEBPACK_PUBLIC_PATH: (argv.watch === true) ? JSON.stringify(config.output.publicPath) : false
     })
   ],
   postcss: [


### PR DESCRIPTION
A new proposition to set public-path dynamically when runnning `npm run watch`. Simpler config and watch.js that fixes http/https.

This addresses the issues in https://github.com/roots/sage/pull/1661.