### PR TITLE
Update _grid.scss to use @include make-col-ready() mixin

### DIFF
--- a/assets/styles/components/_grid.scss
+++ b/assets/styles/components/_grid.scss
@@ -1,6 +1,6 @@
 // Grid system
 .main {
-  @extend %grid-column;
+  @include make-col-ready();
   @include media-breakpoint-up(sm) {
     @include make-col($main-sm-columns);
     .sidebar-primary & {
@@ -9,7 +9,7 @@
   }
 }
 .sidebar {
-  @extend %grid-column;
+  @include make-col-ready();
   @include media-breakpoint-up(sm) {
     @include make-col($sidebar-sm-columns);
   }


### PR DESCRIPTION
Rather @include make-col-ready() as opposed to using @extend %grid-column for classes main and sidebar.
http://v4-alpha.getbootstrap.com/layout/grid/