### PR TITLE
Namespaces on own line

### DIFF
--- a/src/admin.php
+++ b/src/admin.php
@@ -1,4 +1,6 @@
-<?php namespace App;
+<?php
+
+namespace App;
 
 /**
  * Theme customizer

--- a/src/filters.php
+++ b/src/filters.php
@@ -1,4 +1,6 @@
-<?php namespace App;
+<?php
+
+namespace App;
 
 use Roots\Sage\Template;
 use Roots\Sage\Template\Wrapper;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,4 +1,6 @@
-<?php namespace App;
+<?php
+
+namespace App;
 
 use Roots\Sage\Asset;
 use Roots\Sage\Assets\JsonManifest;

--- a/src/lib/Sage/Asset.php
+++ b/src/lib/Sage/Asset.php
@@ -1,4 +1,6 @@
-<?php namespace Roots\Sage;
+<?php
+
+namespace Roots\Sage;
 
 use Roots\Sage\Assets\ManifestInterface;
 

--- a/src/lib/Sage/Assets/JsonManifest.php
+++ b/src/lib/Sage/Assets/JsonManifest.php
@@ -1,4 +1,6 @@
-<?php namespace Roots\Sage\Assets;
+<?php
+
+namespace Roots\Sage\Assets;
 
 /**
  * Class JsonManifest

--- a/src/lib/Sage/Assets/ManifestInterface.php
+++ b/src/lib/Sage/Assets/ManifestInterface.php
@@ -1,4 +1,6 @@
-<?php namespace Roots\Sage\Assets;
+<?php
+
+namespace Roots\Sage\Assets;
 
 /**
  * Interface ManifestInterface

--- a/src/lib/Sage/Template.php
+++ b/src/lib/Sage/Template.php
@@ -1,4 +1,6 @@
-<?php namespace Roots\Sage;
+<?php
+
+namespace Roots\Sage;
 
 use Roots\Sage\Template\Partial;
 use Roots\Sage\Template\WrapperInterface;

--- a/src/lib/Sage/Template/Partial.php
+++ b/src/lib/Sage/Template/Partial.php
@@ -1,4 +1,6 @@
-<?php namespace Roots\Sage\Template;
+<?php
+
+namespace Roots\Sage\Template;
 
 class Partial
 {

--- a/src/lib/Sage/Template/Wrapper.php
+++ b/src/lib/Sage/Template/Wrapper.php
@@ -1,4 +1,6 @@
-<?php namespace Roots\Sage\Template;
+<?php
+
+namespace Roots\Sage\Template;
 
 /**
  * Class Wrapper

--- a/src/lib/Sage/Template/WrapperInterface.php
+++ b/src/lib/Sage/Template/WrapperInterface.php
@@ -1,4 +1,6 @@
-<?php namespace Roots\Sage\Template;
+<?php
+
+namespace Roots\Sage\Template;
 
 /**
  * Interface WrapperInterface

--- a/src/setup.php
+++ b/src/setup.php
@@ -1,4 +1,6 @@
-<?php namespace App;
+<?php
+
+namespace App;
 
 use Roots\Sage\Template;
 


### PR DESCRIPTION
namespace declaration on the same line as <?php isn't being used much anymore. Both PHP FIG and Laravel show the namespace on it's own line.

Reference:
http://www.php-fig.org/psr/psr-2/
https://github.com/laravel/laravel/blob/master/app/User.php#L1-L3