### PR TITLE
Fix #1720: Specify absolute version of Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "sass-loader": "^4.0.2",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
-    "webpack": "^2.1.0-beta.22",
+    "webpack": "2.1.0-beta.22",
     "webpack-dev-middleware": "^1.7.0",
     "webpack-hot-middleware": "^2.12.2"
   },


### PR DESCRIPTION
Webpack `2.1.0-beta.23` has breaking changes related to the configuration structure, so forcing `2.1.0-beta.22` as a temporary fix by removing the `^`.