### PR TITLE
Fix browserSyncOptions in config.js not being passed to BrowserSync

### DIFF
--- a/assets/build/webpack.config.watch.js
+++ b/assets/build/webpack.config.watch.js
@@ -17,7 +17,7 @@ module.exports = {
       publicPath: config.publicPath,
       proxyUrl: config.proxyUrl,
       browserSyncOptions: mergeWithConcat({
-        files: config.watch
+        files: config.watch,
       }, config.browserSyncOptions),
     }),
   ],

--- a/assets/build/webpack.config.watch.js
+++ b/assets/build/webpack.config.watch.js
@@ -1,5 +1,6 @@
 const webpack = require('webpack');
 const BrowserSyncPlugin = require('./webpack.plugin.browsersync');
+const mergeWithConcat = require('./util/mergeWithConcat');
 
 const config = require('./config');
 
@@ -15,7 +16,9 @@ module.exports = {
       target: config.devUrl,
       publicPath: config.publicPath,
       proxyUrl: config.proxyUrl,
-      browserSyncOptions: { files: config.watch },
+      browserSyncOptions: mergeWithConcat({
+        files: config.watch
+      }, config.browserSyncOptions),
     }),
   ],
 };


### PR DESCRIPTION
The options added in "browserSyncOptions" in config.js were not being merged to the watch config.

This fix the issue https://discourse.roots.io/t/sage-9-configure-browsersync/7808