### PR TITLE
Fix duplicate value in Browsersync files Array

### DIFF
--- a/assets/build/config.js
+++ b/assets/build/config.js
@@ -27,10 +27,7 @@ const config = mergeWithConcat({
     watcher: !!argv.watch,
     uglifyJs: !(argv.p || argv.optimizeMinimize),
   },
-  watch: [
-    'templates/**/*.php',
-    'src/**/*.php',
-  ],
+  watch: [],
 }, userConfig);
 
 Object.keys(config.entry).forEach(id =>


### PR DESCRIPTION
The two same values get concatenated. A console.log output of `watcherConfig` in `webpack.plugin.browsersync.js` : 

```
{ 
  host: 'localhost',
  port: '3000',
  proxy: 
   { target: 'https://example.dev',
     middleware: [ [Object], [Object] ] },
  files: 
   [ 'templates/**/*.php',
     'src/**/*.php',
     'templates/**/*.php',
     'src/**/*.php' ]
}
```