### PR TITLE
Use Bedrock-style folder structure on publicPath by default

### DIFF
--- a/assets/build/config.js
+++ b/assets/build/config.js
@@ -27,6 +27,7 @@ const config = mergeWithConcat({
     watcher: !!argv.watch,
     uglifyJs: !(argv.p || argv.optimizeMinimize),
   },
+  publicPath: `/${path.dirname(process.cwd()).split(path.sep).slice(-2).concat(path.basename(process.cwd())).join('/')}`,
   watch: [],
 }, userConfig);
 

--- a/assets/build/config.js
+++ b/assets/build/config.js
@@ -27,7 +27,8 @@ const config = mergeWithConcat({
     watcher: !!argv.watch,
     uglifyJs: !(argv.p || argv.optimizeMinimize),
   },
-  publicPath: `/${path.dirname(process.cwd()).split(path.sep).slice(-2).concat(path.basename(process.cwd())).join('/')}`,
+  publicPath: `/${path.dirname(process.cwd()).split(path.sep).slice(-2).concat(path.basename(process.cwd()))
+    .join('/')}`,
   watch: [],
 }, userConfig);
 

--- a/assets/config.json
+++ b/assets/config.json
@@ -12,7 +12,6 @@
     "templates/**/*.php",
     "src/**/*.php"
   ],
-  "publicPath": "/app/themes/sage",
   "devUrl": "https://example.dev",
   "proxyUrl": "https://localhost:3000",
   "cacheBusting": "[name]_[hash:8]"


### PR DESCRIPTION
Use Bedrock-style folder structure on webpack `publicPath` by default, yet still overridable via `config.json`.
