### PR TITLE
Add support for .ico files

### DIFF
--- a/assets/build/webpack.config.js
+++ b/assets/build/webpack.config.js
@@ -76,7 +76,7 @@ const webpackConfig = {
         }),
       },
       {
-        test: /\.(png|jpe?g|gif|svg)$/,
+        test: /\.(png|jpe?g|gif|svg|ico)$/,
         include: config.paths.assets,
         loaders: [
           `file?${qs.stringify({


### PR DESCRIPTION
Fixes the build error
`ERROR in ./assets/images/favicon.ico
Module parse failed: ...sage/assets/images/favicon.ico Unexpected character '' (1:0)
You may need an appropriate loader to handle this file type.
(Source code omitted for this binary file)
 @ multi files`
