### PR TITLE
Tighten version constraint for illuminate/view

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   "require": {
     "php": ">=5.6.4",
     "composer/installers": "~1.0",
-    "illuminate/view": "^5.3",
+    "illuminate/view": "~5.3.0",
     "jenssegers/blade": "dev-master#59ba2cc"
   },
   "require-dev": {


### PR DESCRIPTION
The version constraint for `illuminate/view` should probably be tighter, as Laravel follows their own flavor of Semver in which breaking changes are allowed between minor releases.

This could potentially create a situation where simply running `composer update` could break the site (eg. after 5.4 is released).