### PR TITLE
Bootstrap 4 alpha 5 dependency update, error recovery for gulp.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "bootstrap": "git://github.com/twbs/bootstrap.git#v4.0.0-alpha.4"
+    "bootstrap": "git://github.com/twbs/bootstrap.git#v4.0.0-alpha.5"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -172,16 +172,15 @@ var writeToManifest = function(directory) {
 // `gulp styles` - Compiles, combines, and optimizes Bower CSS and project CSS.
 // By default this task will only log a warning if a precompiler error is
 // raised. If the `--production` flag is set: this task will fail outright.
-
 gulp.task('styles', ['wiredep'], function () {
-	var merged = merge();
-	manifest.forEachDependency('css', function (dep) {
+  var merged = merge();
+  manifest.forEachDependency('css', function (dep) {
     var cssTasksInstance = cssTasks(dep.name);
     if (!enabled.failStyleTask) {
-        cssTasksInstance.on('error', function (err) {
-            console.error(err.message);
-            this.emit('end');
-        });
+      cssTasksInstance.on('error', function (err) {
+        console.error(err.message);
+        this.emit('end');
+      });
     }
     merged.add(gulp.src(dep.globs, {base: 'styles'})
         .pipe(plumber({errorHandler: onError}))
@@ -194,7 +193,6 @@ gulp.task('styles', ['wiredep'], function () {
 // ### Scripts
 // `gulp scripts` - Runs JSHint then compiles, combines, and optimizes Bower JS
 // and project JS.
-
 gulp.task('scripts', ['jshint'], function() {
   var merged = merge();
   manifest.forEachDependency('js', function(dep) {


### PR DESCRIPTION
See here: https://discourse.roots.io/t/jshint-crashing-gulp-when-a-javascript-error-occurs/6783/8