### PR TITLE
Use Config object to store config options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
   "require": {
     "php": ">=5.6.4",
     "composer/installers": "~1.0",
-    "illuminate/view": "~5.3.0"
+    "illuminate/view": "~5.3.0",
+    "illuminate/config": "~5.3.0"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2fe2f9807abba61c265ec0afe9059117",
-    "content-hash": "3d29aea6e725e8821f18f7f1a088d663",
+    "hash": "971d5df95d501fb79f467c7192ea7965",
+    "content-hash": "50f25d093572c0558c11fb9498cb6603",
     "packages": [
         {
             "name": "composer/installers",
@@ -180,6 +180,51 @@
                 "string"
             ],
             "time": "2015-11-06 14:35:42"
+        },
+        {
+            "name": "illuminate/config",
+            "version": "v5.3.23",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/config.git",
+                "reference": "96bb98f6ffbc1e185d3384cf04062f280b35d3c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/config/zipball/96bb98f6ffbc1e185d3384cf04062f280b35d3c1",
+                "reference": "96bb98f6ffbc1e185d3384cf04062f280b35d3c1",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "5.3.*",
+                "illuminate/filesystem": "5.3.*",
+                "illuminate/support": "5.3.*",
+                "php": ">=5.6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Config\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Config package.",
+            "homepage": "https://laravel.com",
+            "time": "2016-10-17 13:37:58"
         },
         {
             "name": "illuminate/container",

--- a/functions.php
+++ b/functions.php
@@ -42,7 +42,7 @@ array_map(function ($file) {
  * ├── STYLESHEETPATH         -> /srv/www/example.com/current/web/app/themes/sage
  * └── TEMPLATEPATH           -> /srv/www/example.com/current/web/app/themes/sage/templates
  */
-if (is_customize_preview()) {
+if (App\config('sage.disable_option_hack')) {
     return;
 }
 add_filter('template', function ($stylesheet) {

--- a/src/filters.php
+++ b/src/filters.php
@@ -34,7 +34,11 @@ add_filter('excerpt_more', function () {
 array_map(function ($type) {
     add_filter("{$type}_template_hierarchy", function ($templates) {
         return call_user_func_array('array_merge', array_map(function ($template) {
-            $normalizedTemplate = preg_replace(['%^/?(templates)?/?%', '%(\.blade)?(\.php)?$%'], '', $template);
+            $transforms = [
+                '%^/?(templates)?/?%' => config('sage.disable_option_hack') ? 'templates/' : '',
+                '%(\.blade)?(\.php)?$%' => ''
+            ];
+            $normalizedTemplate = preg_replace(array_keys($transforms), array_values($transforms), $template);
             return ["{$normalizedTemplate}.blade.php", "{$normalizedTemplate}.php"];
         }, $templates));
     });
@@ -53,7 +57,7 @@ add_filter('template_include', function ($template) {
     echo template($template, $data);
 
     // Return a blank file to make WordPress happy
-    return get_template_directory() . '/index.php';
+    return dirname(__DIR__).'/index.php';
 }, PHP_INT_MAX);
 
 /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,22 +3,51 @@
 namespace App;
 
 use Roots\Sage\Container;
+use Illuminate\Contracts\Container\Container as ContainerContract;
 
 /**
- * @param string $name
- * @return Container|mixed
+ * Get the sage container.
+ *
+ * @param string $abstract
+ * @param array  $parameters
+ * @param ContainerContract $container
+ * @return ContainerContract|mixed
+ * @SuppressWarnings(PHPMD.StaticAccess)
  */
-function sage($name = '')
+function sage($abstract = null, $parameters = [], ContainerContract $container = null)
 {
-    static $container;
-    if (!$container) {
-        $container = new Container;
+    $container = $container ?: Container::getInstance();
+    if (!$abstract) {
+        return $container;
     }
-    return $name ? (isset($container[$name]) ? $container[$name] : $container["sage.{$name}"]) : $container;
+    return $container->bound($abstract)
+        ? $container->make($abstract, $parameters)
+        : $container->make("sage.{$abstract}", $parameters);
 }
 
 /**
+ * Get / set the specified configuration value.
  *
+ * If an array is passed as the key, we will assume you want to set an array of values.
+ *
+ * @param array|string $key
+ * @param mixed $default
+ * @return mixed|\Roots\Sage\Config
+ * @copyright Taylor Otwell
+ * @link https://github.com/laravel/framework/blob/c0970285/src/Illuminate/Foundation/helpers.php#L254-L265
+ */
+function config($key = null, $default = null)
+{
+    if (is_null($key)) {
+        return sage('config');
+    }
+    if (is_array($key)) {
+        return sage('config')->set($key);
+    }
+    return sage('config')->get($key, $default);
+}
+
+/**
  * @param string $file
  * @param array $data
  * @return string

--- a/src/lib/Sage/Config.php
+++ b/src/lib/Sage/Config.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Roots\Sage;
+
+class Config extends \Illuminate\Config\Repository
+{
+
+}

--- a/src/setup.php
+++ b/src/setup.php
@@ -2,7 +2,9 @@
 
 namespace App;
 
+use Illuminate\Contracts\Container\Container as ContainerContract;
 use Roots\Sage\Assets\JsonManifest;
+use Roots\Sage\Config;
 use Roots\Sage\Template\Blade;
 use Roots\Sage\Template\BladeProvider;
 
@@ -88,30 +90,37 @@ add_action('after_setup_theme', function () {
     /**
      * Sage config
      */
-    sage()->bindIf('config', function () {
-        return [
-            'view.paths'      => [TEMPLATEPATH, STYLESHEETPATH],
-            'view.compiled'   => wp_upload_dir()['basedir'].'/cache/compiled',
-            'view.namespaces' => ['App' => WP_CONTENT_DIR],
-            'assets.manifest' => get_stylesheet_directory().'/dist/assets.json',
-            'assets.uri'      => get_stylesheet_directory_uri().'/dist'
-        ];
-    });
+    $paths = [
+        'dir.stylesheet' => get_stylesheet_directory(),
+        'dir.template'   => get_template_directory(),
+        'dir.upload'     => wp_upload_dir()['basedir'],
+        'uri.stylesheet' => get_stylesheet_directory_uri(),
+        'uri.template'   => get_template_directory_uri(),
+    ];
+    $viewPaths = collect(preg_replace('%[\/]?(templates)?[\/.]*?$%', '', [STYLESHEETPATH, TEMPLATEPATH]))
+        ->flatMap(function ($path) {
+            return ["{$path}/templates", $path];
+        })->unique()->toArray();
+    config([
+        'assets.manifest' => "{$paths['dir.stylesheet']}/dist/assets.json",
+        'assets.uri'      => "{$paths['uri.stylesheet']}/dist",
+        'view.compiled'   => "{$paths['dir.upload']}/cache/compiled",
+        'view.namespaces' => ['App' => WP_CONTENT_DIR],
+        'view.paths'      => $viewPaths,
+    ] + $paths);
 
     /**
      * Add JsonManifest to Sage container
      */
-    sage()->singleton('sage.assets', function ($app) {
-        $config = $app['config'];
-        return new JsonManifest($config['assets.manifest'], $config['assets.uri']);
+    sage()->singleton('sage.assets', function () {
+        return new JsonManifest(config('assets.manifest'), config('assets.uri'));
     });
 
     /**
      * Add Blade to Sage container
      */
-    sage()->singleton('sage.blade', function ($app) {
-        $config = $app['config'];
-        $cachePath = $config['view.compiled'];
+    sage()->singleton('sage.blade', function (ContainerContract $app) {
+        $cachePath = config('view.compiled');
         if (!file_exists($cachePath)) {
             wp_mkdir_p($cachePath);
         }
@@ -126,3 +135,13 @@ add_action('after_setup_theme', function () {
         return '<?= App\\asset_path(\''.trim($asset, '\'"').'\'); ?>';
     });
 });
+
+/**
+ * Init config
+ */
+sage()->bindIf('config', Config::class, true);
+
+/**
+ * Disable option hack if we're in Customizer preview
+ */
+config(['sage.disable_option_hack' => is_customize_preview()]);


### PR DESCRIPTION
Because we run `bindIf` on the container, this won't interfere if someone else is already using their own config binding, assuming they're implementing array and repository interfaces.

Binding is run immediately instead of in an action hook so that we can use it in functions.php.