### PR TITLE
Throw errors if minimum requirements aren't met

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -5,23 +5,46 @@
  */
 
 /**
- * Require Composer autoloader if installed on it's own
+ * Helper function for prettying up errors
+ * @param string $message
+ * @param string $subtitle
+ * @param string $title
  */
-if (file_exists($composer = __DIR__ . '/vendor/autoload.php')) {
-    require_once $composer;
+$error = function ($message, $subtitle = '', $title = '') {
+    $title = $title ?: __('Sage &rsaquo; Error', 'sage');
+    $footer = '<a href="https://roots.io/sage/docs">roots.io/sage/docs</a>';
+    $message = "<h1>{$title}<br><small>{$subtitle}</small></h1><p>{$message}</p><p>{$footer}</p>";
+    wp_die($message, $title);
+};
+
+/**
+ * Ensure compatible version of PHP is used
+ */
+if (version_compare('5.6.4', phpversion(), '>=')) {
+    $error(__('You must be using PHP 5.6.4 or greater.', 'sage'), __('Invalid PHP version', 'sage'));
 }
 
 /**
- * Sage includes
- *
- * The $sage_includes array determines the code library included in your theme.
- * Add or remove files to the array as needed. Supports child theme overrides.
- *
- * Please note that missing files will produce a fatal error.
+ * Ensure dependencies are loaded
  */
-array_map(function ($file) {
-    if (!locate_template("src/{$file}.php", true, true)) {
-        trigger_error(sprintf(__('Error locating %s for inclusion', 'sage'), $file), E_USER_ERROR);
+if (!file_exists($composer = __DIR__.'/vendor/autoload.php') && !class_exists('Roots\\Sage\\Container')) {
+    $error(
+        __('You must run <code>composer install</code> from the Sage directory.', 'sage'),
+        __('Autoloader not found.', 'sage')
+    );
+}
+require_once $composer;
+
+/**
+ * Sage required files
+ *
+ * The mapped array determines the code library included in your theme.
+ * Add or remove files to the array as needed. Supports child theme overrides.
+ */
+array_map(function ($file) use ($error) {
+    $file = "src/{$file}.php";
+    if (!locate_template($file, true, true)) {
+        $error(sprintf(__('Error locating <code>%s</code> for inclusion.', 'sage'), $file), 'File not found');
     }
 }, ['helpers', 'setup', 'filters', 'admin']);
 


### PR DESCRIPTION
Checks for all requirements and throws an error if one isn't met.
* Minimum PHP version (`>= 5.6.4`)
* Autoloader (from Sage directory, Bedrock, or whatever; just has to be able to access Container class)
* Required files
  * helpers.php
  * setup.php
  * filters.php
  * admin.php