### PR TITLE
Update to Bootstrap 4 Alpha 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Update to Bootstrap 4 Alpha 6 ([#1792](https://github.com/roots/sage/pull/1792))
 * Add Blade ([#1765](https://github.com/roots/sage/pull/1765) and [#1777](https://github.com/roots/sage/pull/1777))
 * Remove sidebar defaults ([#1760](https://github.com/roots/sage/pull/1760))
 * Remove post formats ([#1759](https://github.com/roots/sage/pull/1759))

--- a/assets/styles/common/_variables.scss
+++ b/assets/styles/common/_variables.scss
@@ -1,9 +1,6 @@
 // Colors
 $brand-primary:         #27ae60;
 
-// Global options
-$enable-flex:           true;
-
 // Grid settings
 $main-sm-columns:       12;
 $sidebar-sm-columns:    4;

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "webpack-hot-middleware": "^2.13.1"
   },
   "dependencies": {
-    "bootstrap": "^4.0.0-alpha.5",
+    "bootstrap": "^4.0.0-alpha.6",
     "font-awesome": "^4.7.0",
     "jquery": "1.12.4 - 3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -422,12 +422,12 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bootstrap@^4.0.0-alpha.5:
-  version "4.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-alpha.5.tgz#a126b648c3bd2f52b8fad4bbc5e2d0ad2abf7064"
+bootstrap@^4.0.0-alpha.6:
+  version "4.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-alpha.6.tgz#4f54dd33ac0deac3b28407bc2df7ec608869c9c8"
   dependencies:
-    jquery "1.9.1 - 3"
-    tether "^1.3.7"
+    jquery ">=1.9.1"
+    tether "^1.4.0"
 
 brace-expansion@^1.0.0:
   version "1.1.6"
@@ -2726,7 +2726,7 @@ jpegtran-bin@^3.0.0:
     bin-wrapper "^3.0.0"
     logalot "^2.0.0"
 
-"jquery@1.12.4 - 3", "jquery@1.9.1 - 3":
+"jquery@1.12.4 - 3", jquery@>=1.9.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.1.1.tgz#347c1c21c7e004115e0a4da32cece041fad3c8a3"
 
@@ -4901,9 +4901,9 @@ tempfile@^1.0.0:
     os-tmpdir "^1.0.0"
     uuid "^2.0.1"
 
-tether@^1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/tether/-/tether-1.3.7.tgz#65578104741694f9672c808eae04a9adae7b0304"
+tether@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/tether/-/tether-1.4.0.tgz#0f9fa171f75bf58485d8149e94799d7ae74d1c1a"
 
 text-table@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
this also drops the flexbox option we previously enabled, since bs4 is now flexbox by default (and without the option to disable)

http://blog.getbootstrap.com/2017/01/06/bootstrap-4-alpha-6/