### PR TITLE
Only disable customizer if theme isn't activated

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -12,7 +12,7 @@
  */
 $sage_error = function ($message, $subtitle = '', $title = '') {
     $title = $title ?: __('Sage &rsaquo; Error', 'sage');
-    $footer = '<a href="https://roots.io/sage/docs">roots.io/sage/docs</a>';
+    $footer = '<a href="https://roots.io/sage/docs/">roots.io/sage/docs/</a>';
     $message = "<h1>{$title}<br><small>{$subtitle}</small></h1><p>{$message}</p><p>{$footer}</p>";
     wp_die($message, $title);
 };
@@ -57,7 +57,7 @@ array_map(function ($file) use ($sage_error) {
  * We do this so that the Template Hierarchy will look in themes/sage/templates for core WordPress themes
  * But functions.php, style.css, and index.php are all still located in themes/sage
  *
- * This is not fully compatible with Live Preview without the use of a plugin to update the template option.
+ * This is not compatible with the WordPress Customizer theme preview prior to theme activation
  *
  * get_template_directory()   -> /srv/www/example.com/current/web/app/themes/sage
  * get_stylesheet_directory() -> /srv/www/example.com/current/web/app/themes/sage
@@ -65,8 +65,8 @@ array_map(function ($file) use ($sage_error) {
  * ├── STYLESHEETPATH         -> /srv/www/example.com/current/web/app/themes/sage
  * └── TEMPLATEPATH           -> /srv/www/example.com/current/web/app/themes/sage/templates
  */
-if (App\config('sage.disable_option_hack')) {
-    return;
+if (is_customize_preview() && isset($_GET['theme'])) {
+    $sage_error(__('Theme must be activated prior to using the customizer.', 'sage'));
 }
 add_filter('template', function ($stylesheet) {
     return dirname($stylesheet);

--- a/src/setup.php
+++ b/src/setup.php
@@ -146,8 +146,3 @@ add_action('after_setup_theme', function () {
  * Init config
  */
 sage()->bindIf('config', Config::class, true);
-
-/**
- * Disable option hack if we're in Customizer preview
- */
-config(['sage.disable_option_hack' => is_customize_preview()]);


### PR DESCRIPTION
closes #1791 

customizer still won't work prior to theme activation which might be on hold until https://core.trac.wordpress.org/ticket/13239