### PR TITLE
Allow browser versions to be configured in config.json

### DIFF
--- a/assets/build/config.js
+++ b/assets/build/config.js
@@ -26,6 +26,7 @@ const config = mergeWithConcat({
     watcher: !!argv.watch,
   },
   watch: [],
+  browsers: [],
 }, userConfig);
 
 config.watch.push(`${path.basename(config.paths.assets)}/${config.copy}`);

--- a/assets/build/webpack.config.js
+++ b/assets/build/webpack.config.js
@@ -155,7 +155,7 @@ let webpackConfig = {
         output: { path: config.paths.dist },
         context: config.paths.assets,
         postcss: [
-          autoprefixer({ browsers: ['last 2 versions', 'android 4', 'opera 12'] }),
+          autoprefixer({ browsers: config.browsers }),
         ],
       },
     }),

--- a/assets/build/webpack.config.optimize.js
+++ b/assets/build/webpack.config.optimize.js
@@ -11,7 +11,10 @@ module.exports = {
   plugins: [
     new OptimizeCssAssetsPlugin({
       cssProcessor: cssnano,
-      cssProcessorOptions: { discardComments: { removeAll: true } },
+      cssProcessorOptions: {
+        discardComments: { removeAll: true },
+        autoprefixer: { browsers: config.browsers },
+      },
       canPrint: true,
     }),
     new ImageminPlugin({

--- a/assets/config.json
+++ b/assets/config.json
@@ -15,5 +15,10 @@
   "publicPath": "/app/themes/sage",
   "devUrl": "http://example.dev",
   "proxyUrl": "http://localhost:3000",
-  "cacheBusting": "[name]_[hash:8]"
+  "cacheBusting": "[name]_[hash:8]",
+  "browsers": [
+    "last 2 versions",
+    "android 4",
+    "opera 12"
+  ]
 }


### PR DESCRIPTION
As sage is a starter theme it shouldn't make hardcoded assumptions about which browsers are supported. This PR allows users to override the default browser array passed to autoprefixer. It also passes this array on to cssnano to avoid stripping intentional vendor prefixes.