### PR TITLE
Remove Font Awesome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### 9.0.0-beta.2: January 11th, 2016
+* Remove Font Awesome ([#1809](https://github.com/roots/sage/pull/1809))
 * Remove grid defaults ([#1808](https://github.com/roots/sage/pull/1808))
 * Fix for `publicPath` ([#1806](https://github.com/roots/sage/pull/1806))
 * Update clean task name ([#1800](https://github.com/roots/sage/pull/1800))

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -2,7 +2,6 @@
 
 // Import npm dependencies
 @import "~bootstrap/scss/bootstrap";
-@import "~font-awesome/scss/font-awesome";
 
 @import "common/global";
 @import "components/buttons";

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
   },
   "dependencies": {
     "bootstrap": "^4.0.0-alpha.6",
-    "font-awesome": "^4.7.0",
     "jquery": "1.12.4 - 3"
   }
 }


### PR DESCRIPTION
font awesome was added in sage 9 mainly to provide a good example out of the box on how to add a 3rd party package

there's a few issues:

* not everyone wants it
* font awesome includes formats that aren't necessary right now (https://github.com/FortAwesome/Font-Awesome/issues/10470)
* produces webpack warnings about the entrypoint size limit out of the box

this will instead be moved to the docs