### PR TITLE
Add option to change theme file headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-### 9.0.0-beta.2: January 11th, 2016
+### 9.0.0-beta.2: TBD
+* Add option to change theme file headers ([#1811](https://github.com/roots/sage/pull/1811))
+* Add option to remove Bootstrap ([#1810](https://github.com/roots/sage/pull/1810))
 * Remove Font Awesome ([#1809](https://github.com/roots/sage/pull/1809))
 * Remove grid defaults ([#1808](https://github.com/roots/sage/pull/1808))
 * Fix for `publicPath` ([#1806](https://github.com/roots/sage/pull/1806))

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Sage is a WordPress starter theme with a modern development workflow.
 * ES6 for JavaScript
 * [Webpack](https://webpack.github.io/) for compiling assets, optimizing images, and concatenating and minifying files
 * [Browsersync](http://www.browsersync.io/) for synchronized browser testing
-* [Bootstrap 4](http://getbootstrap.com/) for a front-end framework (can be removed or replaced)
+* [Bootstrap 4](http://getbootstrap.com/) for a front-end framework (option to remove during installation)
 * [Laravel's Blade](https://laravel.com/docs/5.3/blade) as a templating engine
 
 See a working example at [roots-example-project.com](https://roots-example-project.com/).
@@ -35,6 +35,11 @@ Install Sage using Composer from your WordPress themes directory (replace `your-
 # @ app/themes/ or wp-content/themes/
 $ composer create-project roots/sage your-theme-name dev-master
 ```
+
+During theme installation you will have the options to:
+
+* Update theme headers (theme name, description, author, etc.)
+* Remove Bootstrap
 
 ## Theme structure
 

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
     "test": [
       "vendor/bin/phpcs"
     ],
-    "post-create-project-cmd": "Roots\\Sage\\PostCreateProject::removeBootstrap"
+    "post-create-project-cmd": [
+        "Roots\\Sage\\PostCreateProject::updateHeaders",
+        "Roots\\Sage\\PostCreateProject::removeBootstrap"
+    ]
   }
 }

--- a/src/lib/Sage/PostCreateProject.php
+++ b/src/lib/Sage/PostCreateProject.php
@@ -6,11 +6,39 @@ use Composer\Script\Event;
 
 class PostCreateProject
 {
+    public static function updateHeaders(Event $event)
+    {
+        // @codingStandardsIgnoreStart
+        $io = $event->getIO();
+
+        if ($io->isInteractive()) {
+            $io->write('<info>Define theme headers. Press enter key for default.</info>');
+
+            $theme_headers_default = [
+                'name'        => 'Sage Starter Theme',
+                'uri'         => 'https://roots.io/sage/',
+                'description' => 'Sage is a WordPress starter theme.',
+                'version'     => '9.0.0-beta.2',
+                'author'      => 'Roots',
+                'author_uri'  => 'https://roots.io/'
+            ];
+            $theme_headers = [
+              'name'        => $io->ask('<info>Theme Name [<comment>'.$theme_headers_default['name'].'</comment>]:</info> ', $theme_headers_default['name']),
+              'uri'         => $io->ask('<info>Theme URI [<comment>'.$theme_headers_default['uri'].'</comment>]:</info> ', $theme_headers_default['uri']),
+              'description' => $io->ask('<info>Theme Description [<comment>'.$theme_headers_default['description'].'</comment>]:</info> ', $theme_headers_default['description']),
+              'version'     => $io->ask('<info>Theme Version [<comment>'.$theme_headers_default['version'].'</comment>]:</info> ', $theme_headers_default['version']),
+              'author'      => $io->ask('<info>Theme Author [<comment>'.$theme_headers_default['author'].'</comment>]:</info> ', $theme_headers_default['author']),
+              'author_uri'  => $io->ask('<info>Theme Author URI [<comment>'.$theme_headers_default['author_uri'].'</comment>]:</info> ', $theme_headers_default['author_uri'])
+            ];
+
+            file_put_contents('style.css', str_replace($theme_headers_default, $theme_headers, file_get_contents('style.css')));
+        }
+    }
+
     public static function removeBootstrap(Event $event)
     {
         $io = $event->getIO();
 
-        // @codingStandardsIgnoreStart
         if ($io->isInteractive()) {
             if ($io->askConfirmation('<info>Remove Bootstrap?</info> [<comment>y,N</comment>]? ', false)) {
                 file_put_contents('package.json', str_replace('    "bootstrap": "^4.0.0-alpha.6",' . "\n", '', file_get_contents('package.json')));
@@ -23,6 +51,6 @@ class PostCreateProject
                 file_put_contents('assets/styles/layouts/_header.scss', '');
             }
         }
-        // @codingStandardsIgnoreEnd
     }
+    // @codingStandardsIgnoreEnd
 }

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name:         Sage Starter Theme
 Theme URI:          https://roots.io/sage/
-Description:        Sage is a WordPress starter theme. <a href="https://github.com/roots/sage">Contribute on GitHub</a>
+Description:        Sage is a WordPress starter theme.
 Version:            9.0.0-beta.2
 Author:             Roots
 Author URI:         https://roots.io/


### PR DESCRIPTION
now allow for `style.css` / theme headers to be customized upon creation of a sage project:

![image](https://cloud.githubusercontent.com/assets/115911/21965447/2a96f36a-db1d-11e6-86ae-822ac8b4146e.png)

since we're requiring composer and it's the recommended way to create a new sage project, we've got a lot of options.

(such as allowing users to remove bootstrap on project creation (#1810))

 follow up PRs will include the ability to change theme slug, add font awesome, and possibly more.