### PR TITLE
Add option to configure build settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### HEAD
-* Add option to configure Browsersync ([#1822](https://github.com/roots/sage/pull/1822))
+* Add option to configure build settings ([#1822](https://github.com/roots/sage/pull/1822))
 * Add support for HTML injection ([#1817](https://github.com/roots/sage/pull/1817))
 
 ### 9.0.0-beta.2: January 19th, 2016

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### HEAD
+* Add option to configure Browsersync ([#1822](https://github.com/roots/sage/pull/1822))
+* Add support for HTML injection ([#1817](https://github.com/roots/sage/pull/1817))
+
 ### 9.0.0-beta.2: January 19th, 2016
 * Fix Browersync ([#1815](https://github.com/roots/sage/pull/1815))
 * Add option to select CSS framework, add Foundation as an option ([#1813](https://github.com/roots/sage/pull/1813))

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ During theme installation you will have the options to:
 * Update theme headers (theme name, description, author, etc.)
 * Select a CSS framework (Bootstrap, Foundation, none)
 * Add Font Awesome
+* Configure Browsersync (path to theme, local development URL)
 
 ## Theme structure
 

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
     "post-create-project-cmd": [
         "Roots\\Sage\\PostCreateProject::updateHeaders",
         "Roots\\Sage\\PostCreateProject::selectFramework",
-        "Roots\\Sage\\PostCreateProject::addFontAwesome"
+        "Roots\\Sage\\PostCreateProject::addFontAwesome",
+        "Roots\\Sage\\PostCreateProject::configureBrowsersync"
     ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "Roots\\Sage\\PostCreateProject::updateHeaders",
         "Roots\\Sage\\PostCreateProject::selectFramework",
         "Roots\\Sage\\PostCreateProject::addFontAwesome",
-        "Roots\\Sage\\PostCreateProject::configureBrowsersync"
+        "Roots\\Sage\\PostCreateProject::buildOptions"
     ]
   }
 }

--- a/src/lib/Sage/PostCreateProject.php
+++ b/src/lib/Sage/PostCreateProject.php
@@ -91,11 +91,33 @@ class PostCreateProject
                 $package['dependencies'] = $dependencies;
                 $package = str_replace('    ', '  ', json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
                 file_put_contents('package.json', $package);
-                
+
                 $import_dep_str = '// Import npm dependencies' . "\n";
                 file_put_contents('assets/styles/main.scss', str_replace($import_dep_str, $import_dep_str . '@import "~font-awesome/scss/font-awesome";' . "\n", file_get_contents('assets/styles/main.scss')));
                 file_put_contents('assets/styles/common/_variables.scss', "\n" . '$fa-font-path:          \'~font-awesome/fonts\';' . "\n", FILE_APPEND);
             }
+        }
+    }
+
+    public static function configureBrowsersync(Event $event)
+    {
+        $io = $event->getIO();
+
+        if ($io->isInteractive()) {
+            $io->write('<info>Configure Browsersync. Press enter key for default.</info>');
+
+            $browsersync_settings_default = [
+                'publicPath'  => '/app/themes/'.basename(getcwd()),
+                'devUrl'      => 'http://example.dev'
+            ];
+
+            $browsersync_settings = [
+                'publicPath'  => $io->ask('<info>Path to theme directory (eg. /wp-content/themes/sage) [<comment>'.$browsersync_settings_default['publicPath'].'</comment>]:</info> ', $browsersync_settings_default['publicPath']),
+                'devUrl'      => $io->ask('<info>Local development URL of WP site [<comment>'.$browsersync_settings_default['devUrl'].'</comment>]:</info> ', $browsersync_settings_default['devUrl'])
+            ];
+
+            file_put_contents('assets/config.json', str_replace('/app/themes/sage', $browsersync_settings['publicPath'], file_get_contents('assets/config.json')));
+            file_put_contents('assets/config.json', str_replace($browsersync_settings_default['devUrl'], $browsersync_settings['devUrl'], file_get_contents('assets/config.json')));
         }
     }
     // @codingStandardsIgnoreEnd

--- a/src/lib/Sage/PostCreateProject.php
+++ b/src/lib/Sage/PostCreateProject.php
@@ -99,12 +99,12 @@ class PostCreateProject
         }
     }
 
-    public static function configureBrowsersync(Event $event)
+    public static function buildOptions(Event $event)
     {
         $io = $event->getIO();
 
         if ($io->isInteractive()) {
-            $io->write('<info>Configure Browsersync. Press enter key for default.</info>');
+            $io->write('<info>Configure build settings. Press enter key for default.</info>');
 
             $browsersync_settings_default = [
                 'publicPath'  => '/app/themes/'.basename(getcwd()),


### PR DESCRIPTION
new addition to the post-install options — options for setting the path to the theme folder and defining your local development URL (defined in `assets/config.json`)

![image](https://cloud.githubusercontent.com/assets/115911/22409210/3ae6d024-e643-11e6-9d9d-b7f4d8525470.png)
