### PR TITLE
Set trim_trailing_whitespace to false for *.md files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ indent_size = 4
 
 [templates/**.php]
 indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
The title speaks for it's self.

I added this to allow proper editing of *.md files within' the theme directory such as adding new lines with double spaces.

This is my first attempt at a pull request, so please let me know if I did something wrong.

Thanks