### PR TITLE
Use latest Node 4.x in Travis CI builds (Sage 8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ php:
   - 5.4
   - hhvm
 
+env:
+  - TRAVIS_NODE_VERSION="4"
+
 matrix:
   allow_failures:
     - php: nightly
@@ -17,6 +20,8 @@ cache:
     - node_modules
 
 install:
+  - nvm install $TRAVIS_NODE_VERSION
+  - nvm use $TRAVIS_NODE_VERSION
   - npm install -g npm@latest
   - npm install -g bower gulp jscs
   - npm install


### PR DESCRIPTION
NPM no longer supports Node 0.10.36 which is used by Travis CI by default, resulting in failed builds. This PR specifies that Travis should use Node 4.x when building, as stated in the project requirements.