### PR TITLE
Fix gulp error handling (Sage 8)

### DIFF
--- a/assets/styles/common/_variables.scss
+++ b/assets/styles/common/_variables.scss
@@ -1,5 +1,4 @@
 // Grid settings
-$enable-flex:           true;
 $main-sm-columns:       12;
 $sidebar-sm-columns:    4;
 

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "bootstrap": "git://github.com/twbs/bootstrap.git#v4.0.0-alpha.4"
+    "bootstrap": "git://github.com/twbs/bootstrap.git#v4.0.0-alpha.6"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,6 +67,12 @@ var enabled = {
 // Path to the compiled assets manifest in the dist directory
 var revManifest = path.dist + 'assets.json';
 
+// Error checking; produce an error rather than crashing.
+var onError = function(err) {
+  console.log(err.toString());
+  this.emit('end');
+};
+
 // ## Reusable Pipelines
 // See https://github.com/OverZealous/lazypipe
 
@@ -177,6 +183,7 @@ gulp.task('styles', ['wiredep'], function() {
       });
     }
     merged.add(gulp.src(dep.globs, {base: 'styles'})
+      .pipe(plumber({errorHandler: onError}))
       .pipe(cssTasksInstance));
   });
   return merged
@@ -191,6 +198,7 @@ gulp.task('scripts', ['jshint'], function() {
   manifest.forEachDependency('js', function(dep) {
     merged.add(
       gulp.src(dep.globs, {base: 'scripts'})
+        .pipe(plumber({errorHandler: onError}))
         .pipe(jsTasks(dep.name))
     );
   });


### PR DESCRIPTION
This PR is basically just a rebased version of #1814 with a few whitespace and indentation fixes, sqashed down to two commits. It addresses the `gulp watch` issue mentioned on [Discourse](https://discourse.roots.io/t/jshint-crashing-gulp-when-a-javascript-error-occurs/6783).

It also updates Bootstrap to version 4.0.0-alpha.6 and removes the `$enable-flex` var.