### PR TITLE
Fix gulp imagemin options

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -220,11 +220,11 @@ gulp.task('fonts', function() {
 // `gulp images` - Run lossless compression on all the images.
 gulp.task('images', function() {
   return gulp.src(globs.images)
-    .pipe(imagemin({
-      progressive: true,
-      interlaced: true,
-      svgoPlugins: [{removeUnknownsAndDefaults: false}, {cleanupIDs: false}]
-    }))
+    .pipe(imagemin([
+      imagemin.jpegtran({progressive: true}),
+      imagemin.gifsicle({interlaced: true}),
+      imagemin.svgo({plugins: [{removeUnknownsAndDefaults: false}, {cleanupIDs: false}]})
+    ]))
     .pipe(gulp.dest(path.dist + 'images'))
     .pipe(browserSync.stream());
 });


### PR DESCRIPTION
Image minification options (specifically SVG plugin options) were not
working when using the latest version of gulp-imagemin due to a new
options passing structure, see:
https://github.com/sindresorhus/gulp-imagemin/releases/tag/v3.0.0