### PR TITLE
Check for dynamic env DEVURL before config

### DIFF
--- a/assets/build/webpack.config.watch.js
+++ b/assets/build/webpack.config.watch.js
@@ -15,7 +15,7 @@ module.exports = {
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoEmitOnErrorsPlugin(),
     new BrowserSyncPlugin({
-      target: config.devUrl,
+      target: process.env.DEVURL || config.devUrl,
       proxyUrl: config.proxyUrl,
       watch: config.watch,
       delay: 500,


### PR DESCRIPTION
This makes it possible to watch files on a different URL than what is configured in `assets/config.json`.

I find this useful when working with a Multisite install on sub-domains and want to watch while working on a sub-site.

Or when working together with developers that have a different LAMP stack than Trellis. This doesn't require changing and commiting changes to `assets/config.json` simply start the process with:

`DEVURL=https://subsite.example.dev npm start`