### PR TITLE
Add version check for WordPress version less than 4.7.0

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -25,6 +25,13 @@ if (version_compare('5.6.4', phpversion(), '>=')) {
 }
 
 /**
+ * Ensure compatible version of WordPress is used
+ */
+if (version_compare('4.7.0', get_bloginfo('version'), '>=')) {
+    $sage_error(__('You must be using WordPress 4.7.0 or greater.', 'sage'), __('Invalid WordPress version', 'sage'));
+}
+
+/**
  * Ensure dependencies are loaded
  */
 if (!class_exists('Roots\\Sage\\Container')) {


### PR DESCRIPTION
Sage checks if the version of PHP installed is less than 5.6. However, if the installed version of WordPress is less than 4.7, a fatal error is thrown. This check produces a more friendly "Sage Style" error instead of a boring default php fatal error. 

See: https://discourse.roots.io/t/undefined-function-app-get-theme-file-path/8455