### PR TITLE
Add Aside Post Format & Single Partial

### DIFF
--- a/src/setup.php
+++ b/src/setup.php
@@ -51,6 +51,12 @@ add_action('after_setup_theme', function () {
     add_theme_support('post-thumbnails');
 
     /**
+     * Enable post formats
+     * @link https://developer.wordpress.org/themes/functionality/post-formats/
+     */
+    add_theme_support('post-formats', ['aside']);
+
+    /**
      * Enable HTML5 markup support
      * @link https://developer.wordpress.org/reference/functions/add_theme_support/#html5
      */

--- a/templates/partials/content-single-aside.blade.php
+++ b/templates/partials/content-single-aside.blade.php
@@ -1,0 +1,13 @@
+<article @php(post_class())>
+  <header>
+    <h1 class="entry-title">{{ get_the_title() }}</h1>
+    @include('partials/entry-meta')
+  </header>
+  <div class="entry-content lead">
+    @php(the_content())
+  </div>
+  <footer>
+    {!! wp_link_pages(['before' => '<nav class="page-nav"><p>' . __('Pages:', 'sage'), 'after' => '</p></nav>']) !!}
+  </footer>
+  @php(comments_template('/templates/partials/comments.blade.php'))
+</article>

--- a/templates/single.blade.php
+++ b/templates/single.blade.php
@@ -2,7 +2,6 @@
 
 @section('content')
   @while(have_posts()) @php(the_post())
-    @include('partials/content-single-'.get_post_type())
+    @include('partials/content-single-'.(get_post_type() != 'post' ? get_post_type() : get_post_format()))
   @endwhile
 @endsection
-


### PR DESCRIPTION
Add a single post format (`aside`) to help start themes that utilize this feature. Similar to the `template-custom.blade.php`, only a single partial is available to educate the developer on how to create most post formats if needed.

`single.blade.php` loops through `post_type` then `post_format` if the type is a standard post.

This is simple enough to expand and add more formats if needed and even easier to disable without affecting functionality. Only a single partial file was created.