### PR TITLE
Add webpack loader for .json and .xml

### DIFF
--- a/assets/build/webpack.config.js
+++ b/assets/build/webpack.config.js
@@ -93,6 +93,13 @@ let webpackConfig = {
           name: `vendor/${config.cacheBusting}.[ext]`,
         },
       },
+      {
+        test: /\.(json|xml)$/,
+        include: config.paths.assets,
+        loader: `file?${qs.stringify({
+          name: '[path][name].[ext]',
+        })}`,
+      },
     ],
   },
   resolve: {


### PR DESCRIPTION
I like adding favicons folder to `assets/images/favicons`. Usually I generate favicons using http://realfavicongenerator.net/ or similar service. Favicon folder contains their own `browserconfig.xml` and `manifest.json`.

This PR keeps those files in `dist/images/favicons/` and makes it easy to just copy the generated `<meta />`-tags to add favicons.