### PR TITLE
fix caption display

### DIFF
--- a/assets/styles/components/_wp-classes.scss
+++ b/assets/styles/components/_wp-classes.scss
@@ -32,8 +32,14 @@
 
 // Captions
 .wp-caption {
+  @extend .figure;
+}
+.wp-caption>img{
   @extend .figure-img;
   @extend .img-fluid;
+}
+.wp-caption-text {
+  @extend .figure-caption;
 }
 .wp-caption-text {
   @extend .figure-caption;


### PR DESCRIPTION
.wp-caption is the FIGURE element and should extend .figure, contained IMG should extend .figure-img