### PR TITLE
illuminate: container make with parameters

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -21,8 +21,8 @@ function sage($abstract = null, $parameters = [], ContainerContract $container =
         return $container;
     }
     return $container->bound($abstract)
-        ? $container->make($abstract, $parameters)
-        : $container->make("sage.{$abstract}", $parameters);
+        ? $container->makeWith($abstract, $parameters)
+        : $container->makeWith("sage.{$abstract}", $parameters);
 }
 
 /**


### PR DESCRIPTION
Since Illuminate 5.4, `$container->make` with `$parameters` is `$container->makeWith` : https://github.com/illuminate/container/blob/8fbb101a6081786e830cb89d1a1faa846c2c0442/Container.php#L547-L568

Related: 
* https://github.com/roots/sage/commit/f242cb50e9033af815ec56c7346d7f9da4b23460
* https://github.com/illuminate/container/commit/1fc0d2451e23d2ea73c10462d74add4767e2b74c