### PR TITLE
Add conditon for redirect if ['REQUEST_URI'] is not set

### DIFF
--- a/resources/functions.php
+++ b/resources/functions.php
@@ -86,6 +86,8 @@ add_filter('stylesheet_directory_uri', function ($uri) {
 });
 if ($sage_views !== get_option('stylesheet')) {
     update_option('stylesheet', $sage_views);
-    wp_redirect($_SERVER['REQUEST_URI']);
-    exit();
+    if($_SERVER['REQUEST_URI']) {
+        wp_redirect($_SERVER['REQUEST_URI']);
+        exit();
+    }
 }


### PR DESCRIPTION
…exists (e.g. wp-cli)

In cases where the theme is being activated by wp-cli `wp theme activate sage/resources` the $_SERVER['REQUEST_URI'] may not be set, thus causing an error in wp-cli.