### PR TITLE
Optimize CSS Assets safe = true

### DIFF
--- a/resources/assets/build/webpack.config.optimize.js
+++ b/resources/assets/build/webpack.config.optimize.js
@@ -14,6 +14,7 @@ module.exports = {
       cssProcessorOptions: {
         discardComments: { removeAll: true },
         autoprefixer: {},
+        safe: true,
       },
       canPrint: true,
     }),


### PR DESCRIPTION
I was running into some issues on production builds with z-indexes as well as a few more advanced background gradients, etc. [This issue](https://github.com/vuejs-templates/webpack/issues/614) linked to a solution I thought I should try which fixed it right away. By default I think this should be included in all builds.