### PR TITLE
Moved title() helper to app.php controller

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -87,27 +87,3 @@ function display_sidebar()
     isset($display) || $display = apply_filters('sage/display_sidebar', false);
     return $display;
 }
-
-/**
- * Page titles
- * @return string
- */
-function title()
-{
-    if (is_home()) {
-        if ($home = get_option('page_for_posts', true)) {
-            return get_the_title($home);
-        }
-        return __('Latest Posts', 'sage');
-    }
-    if (is_archive()) {
-        return get_the_archive_title();
-    }
-    if (is_search()) {
-        return sprintf(__('Search Results for %s', 'sage'), get_search_query());
-    }
-    if (is_404()) {
-        return __('Not Found', 'sage');
-    }
-    return get_the_title();
-}

--- a/resources/controllers/App.php
+++ b/resources/controllers/App.php
@@ -10,4 +10,28 @@ class App extends Controller
     {
         return get_bloginfo('name');
     }
+
+    /**
+     * Page titles
+     * @return string
+     */
+    public static function title()
+    {
+        if (is_home()) {
+            if ($home = get_option('page_for_posts', true)) {
+                return get_the_title($home);
+            }
+            return __('Latest Posts', 'sage');
+        }
+        if (is_archive()) {
+            return get_the_archive_title();
+        }
+        if (is_search()) {
+            return sprintf(__('Search Results for %s', 'sage'), get_search_query());
+        }
+        if (is_404()) {
+            return __('Not Found', 'sage');
+        }
+        return get_the_title();
+    }
 }

--- a/resources/controllers/App.php
+++ b/resources/controllers/App.php
@@ -11,10 +11,6 @@ class App extends Controller
         return get_bloginfo('name');
     }
 
-    /**
-     * Page titles
-     * @return string
-     */
     public static function title()
     {
         if (is_home()) {

--- a/resources/views/partials/page-header.blade.php
+++ b/resources/views/partials/page-header.blade.php
@@ -1,3 +1,3 @@
 <div class="page-header">
-  <h1>{!! App\title() !!}</h1>
+  <h1>{!! App::title() !!}</h1>
 </div>


### PR DESCRIPTION
Apart from being another controller example, I think it makes more sense the `title()` method being inside the `app.php` controller instead of the `helpers.php` (which has much more blade related code than "templating" code).