### PR TITLE
Add browserSync key to config.json

### DIFF
--- a/resources/assets/build/config.js
+++ b/resources/assets/build/config.js
@@ -25,6 +25,9 @@ const config = merge({
     watcher: !!argv.watch,
   },
   watch: [],
+  browserSync: {
+    open: true
+  }
 }, userConfig);
 
 module.exports = merge(config, {

--- a/resources/assets/build/webpack.config.watch.js
+++ b/resources/assets/build/webpack.config.watch.js
@@ -29,6 +29,9 @@ module.exports = {
       proxyUrl: config.proxyUrl,
       watch: config.watch,
       delay: 500,
+      advanced: {
+        browserSync: config.browserSync
+      }
     }),
   ],
 };

--- a/resources/assets/config.json
+++ b/resources/assets/config.json
@@ -14,5 +14,8 @@
   "cacheBusting": "[name]_[hash:8]",
   "watch": [
     "{app,resources/views}/**/*.php"
-  ]
+  ],
+  "browserSync": {
+    "open": true
+  }
 }


### PR DESCRIPTION
As described in #1915 I've added a browserSync key to the `resource/assets/config.json` where any [BrowserSync related options](https://browsersync.io/docs/options/) can be set.