### PR TITLE
PHP 7+ is now required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: trusty
 php:
   - 7.1
   - 7.0
-  - 5.6
   - nightly
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+### HEAD
+* Update dependencies, support `config-local.json`, implement autoload system for styles/scripts, use `roots/sage-installer`, use `roots/sage-lib` ([#1919](https://github.com/roots/sage/pull/1919))
+* Add soberwp/controller ([#1903](https://github.com/roots/sage/pull/1903))
+* Change syntax of template call to match other files in views ([#1908](https://github.com/roots/sage/pull/1908))
+* Add Tachyons as a CSS framework option ([#1867](https://github.com/roots/sage/pull/1867))
+* Remove post format reference in template call ([#1904](https://github.com/roots/sage/pull/1904))
+* Update inline documentation to reflect correct theme file locations ([#1890](https://github.com/roots/sage/pull/1890))
+* Optimize CSS Assets safe = true ([#1901](https://github.com/roots/sage/pull/1901))
+* Update Autoprefixer and standardize browserlist location ([#1899](https://github.com/roots/sage/pull/1899))
+* Do not redirect for WP-CLI ([#1891](https://github.com/roots/sage/pull/1891))
+* Illuminate: container make with parameters ([#1888](https://github.com/roots/sage/pull/1888))
+* Add Stylelint for linting stylesheets ([#1885](https://github.com/roots/sage/pull/1885))
+
 ### 9.0.0-beta.3: April 21st, 2017
 * Move required theme files to `sage/resources` ([#1877](https://github.com/roots/sage/pull/1877))
 * Move `src/` to `app/` ([#1868](https://github.com/roots/sage/pull/1868))

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See a working example at [roots-example-project.com](https://roots-example-proje
 Make sure all dependencies have been installed before moving on:
 
 * [WordPress](https://wordpress.org/) >= 4.7
-* [PHP](http://php.net/manual/en/install.php) >= 5.6.4
+* [PHP](http://php.net/manual/en/install.php) >= 7.0
 * [Composer](https://getcomposer.org/download/)
 * [Node.js](http://nodejs.org/) >= 6.9.x
 * [Yarn](https://yarnpkg.com/en/docs/install)

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     }
   },
   "require": {
-    "php": ">=5.6.4",
+    "php": ">=7",
     "composer/installers": "~1.0",
     "illuminate/support": "~5.4",
     "roots/sage-lib": "~9.0.0-beta.3",

--- a/resources/functions.php
+++ b/resources/functions.php
@@ -23,8 +23,8 @@ $sage_error = function ($message, $subtitle = '', $title = '') {
 /**
  * Ensure compatible version of PHP is used
  */
-if (version_compare('5.6.4', phpversion(), '>=')) {
-    $sage_error(__('You must be using PHP 5.6.4 or greater.', 'sage'), __('Invalid PHP version', 'sage'));
+if (version_compare('7', phpversion(), '>=')) {
+    $sage_error(__('You must be using PHP 7 or greater.', 'sage'), __('Invalid PHP version', 'sage'));
 }
 
 /**


### PR DESCRIPTION
recent updates accidentally made php 7 the required minimum version and we're gonna roll with it.

closes #1933