### PR TITLE
Ensure templates filenames without path and extension.

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -81,12 +81,25 @@ function asset_path($asset)
  */
 function filter_templates($templates)
 {
+    $paths = apply_filters('sage/filter_templates/paths', [
+        'views',
+        'resources/views'
+    ]);
+    $paths_pattern = "#^(" . implode('|', $paths) . ")/#";
+
     return collect($templates)
-        ->map(function ($template) {
-            return preg_replace('#\.(blade\.)?php$#', '', ltrim($template));
+        ->map(function ($template) use ($paths_pattern) {
+            /** Remove .blade.php/.blade/.php from template names */
+            $template = preg_replace('#\.(blade\.?)?(php)?$#', '', ltrim($template));
+
+            /** Remove partial $paths from the beginning of template names */
+            if (strpos($template, '/')) {
+                $template = preg_replace($paths_pattern, '', $template);
+            }
+
+            return $template;
         })
-        ->flatMap(function ($template) {
-            $paths = apply_filters('sage/filter_templates/paths', ['views', 'resources/views']);
+        ->flatMap(function ($template) use ($paths) {
             return collect($paths)
                 ->flatMap(function ($path) use ($template) {
                     return [


### PR DESCRIPTION
I was reading the solution (#1939) to fix #1936 and came up with an alternative fix by changing the 

```php
    return collect($templates)
        ->map(function ($template) {
            return preg_replace('#\.(blade\.)?php$#', '', ltrim($template));
        })
...
```

with 

```php
    return collect($templates)
        ->map(function ($template) {
            return basename(basename(ltrim($template), '.php'), '.blade');
        })
...
```

