### PR TITLE
Fix Popper for Bootstrap 4

### DIFF
--- a/resources/assets/build/webpack.config.js
+++ b/resources/assets/build/webpack.config.js
@@ -151,7 +151,7 @@ let webpackConfig = {
       $: 'jquery',
       jQuery: 'jquery',
       'window.jQuery': 'jquery',
-      Popper: 'popper.js',
+      Popper: 'popper.js/dist/umd/popper.js',
     }),
     new webpack.LoaderOptionsPlugin({
       minimize: config.enabled.optimize,


### PR DESCRIPTION
This is in reference to #1945, I figured out what was wrong. Bootstrap's [dropdown documentation](https://getbootstrap.com/docs/4.0/components/dropdowns/) indicates the "umd" version of Popper (poorly; you have to look at the actual URL they link to) which fixes the issue of dropdowns not working in Sage Beta 4. 