### PR TITLE
Issue #1950: Fix lint:styles script not matching files in deep subdirectories

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "rmdist": "rimraf dist",
     "lint": "npm run -s lint:scripts && npm run -s lint:styles",
     "lint:scripts": "eslint resources/assets/scripts resources/assets/build",
-    "lint:styles": "stylelint resources/assets/styles/**/*.{css,sass,scss,sss,less}",
+    "lint:styles": "stylelint 'resources/assets/styles/**/*.{css,sass,scss,sss,less}'",
     "test": "npm run -s lint"
   },
   "engines": {


### PR DESCRIPTION
Fix #1950 by not relying on the user's shell but rather passing the unexpanded pattern directly to `stylelint` which in turn expands it using `node-glob`.