### PR TITLE
Followup #1950: Fix lint:styles task with cmd.exe

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "rmdist": "rimraf dist",
     "lint": "npm run -s lint:scripts && npm run -s lint:styles",
     "lint:scripts": "eslint resources/assets/scripts resources/assets/build",
-    "lint:styles": "stylelint 'resources/assets/styles/**/*.{css,sass,scss,sss,less}'",
+    "lint:styles": "stylelint \"resources/assets/styles/**/*.{css,sass,scss,sss,less}\"",
     "test": "npm run -s lint"
   },
   "engines": {


### PR DESCRIPTION
See https://github.com/roots/sage/pull/1951#issuecomment-323593159

Note that I haven't tested this on windows.