### PR TITLE
Move /controllers to app, remove app/lib/Sage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ During theme installation you will have the options to:
 ```shell
 themes/your-theme-name/   # → Root of your Sage based theme
 ├── app/                  # → Theme PHP
-│   ├── lib/Sage/         # → Blade implementation, asset manifest
+│   ├── controllers/      # → Controller files
 │   ├── admin.php         # → Theme customizer setup
 │   ├── filters.php       # → Theme filters
 │   ├── helpers.php       # → Helper functions
@@ -74,7 +74,6 @@ themes/your-theme-name/   # → Root of your Sage based theme
 │   │   ├── images/       # → Theme images
 │   │   ├── scripts/      # → Theme JS
 │   │   └── styles/       # → Theme stylesheets
-│   ├── controllers/      # → Controller files
 │   ├── functions.php     # → Composer autoloader, theme includes
 │   ├── index.php         # → Never manually edit
 │   ├── screenshot.png    # → Theme screenshot for WP admin


### PR DESCRIPTION
Aligns readme.md with the relocation of `controllers` in #1954 and #1959, and reflects the removal of `app/lib/Sage` in #1919.