### PR TITLE
Fix stylelint error with Bulma

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
   "stylelint": {
     "extends": "stylelint-config-standard",
     "rules": {
-      "no-empty-source": null
+      "no-empty-source": null,
+      "function-name-case": ["lower", { "ignoreFunctions": ["/^find.*$/"] }]
     }
   },
   "scripts": {


### PR DESCRIPTION
Running `yarn run lint:styles` throws errors: 
```
resources/assets/styles/common/_derived-variables.scss
 16:17  ✖  Expected "findColorInvert" to be "findcolorinvert"   function-name-case
 17:17  ✖  Expected "findColorInvert" to be "findcolorinvert"   function-name-case
 18:16  ✖  Expected "findColorInvert" to be "findcolorinvert"   function-name-case
 19:20  ✖  Expected "findColorInvert" to be "findcolorinvert"   function-name-case
 20:15  ✖  Expected "findColorInvert" to be "findcolorinvert"   function-name-case
 21:17  ✖  Expected "findColorInvert" to be "findcolorinvert"   function-name-case
 22:14  ✖  Expected "findColorInvert" to be "findcolorinvert"   function-name-case
 42:15  ✖  Expected "findColorInvert" to be "findcolorinvert"   function-name-case
```
Using the rule added to package.json excludes these functions.