### PR TITLE
Update template hierarchy

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -109,10 +109,12 @@ function filter_templates($templates)
                     return [
                         "{$path}/{$template}.blade.php",
                         "{$path}/{$template}.php",
-                        "{$template}.blade.php",
-                        "{$template}.php",
                     ];
-                });
+                })
+                ->concat([
+                    "{$template}.blade.php",
+                    "{$template}.php",
+                ]);
         })
         ->filter()
         ->unique()


### PR DESCRIPTION
All sage/filter_templates/paths have now higher priority than stand-alone template files. Fixes #1979.