### PR TITLE
Swapped browsehappy.com for outdatedbrowser.com

### DIFF
--- a/base.php
+++ b/base.php
@@ -11,7 +11,7 @@ use Roots\Sage\Wrapper;
   <body <?php body_class(); ?>>
     <!--[if IE]>
       <div class="alert alert-warning">
-        <?php _e('You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.', 'sage'); ?>
+        <?php _e('You are using an <strong>outdated</strong> browser. Please <a href="http://outdatedbrowser.com/">upgrade your browser</a> to improve your experience.', 'sage'); ?>
       </div>
     <![endif]-->
     <?php


### PR DESCRIPTION
Currently [BrowseHappy.com](http://browsehappy.com) has a 403 Forbidden error. Swapped it for the [Outdated Browser Project notice URL](http://outdatedbrowser.com) (from [@burocratik](https://github.com/burocratik/outdated-browser)).