### PR TITLE
use relative link for publicPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Edit `app/setup.php` to enable or disable theme features, setup navigation menus
 * Run `yarn` from the theme directory to install dependencies
 * Update `resources/assets/config.json` settings:
   * `devUrl` should reflect your local development hostname
-  * `publicPath` should reflect your WordPress folder structure (`/wp-content/themes/sage` for non-[Bedrock](https://roots.io/bedrock/) installs)
+  * `publicPath` should reflect your WordPress folder structure (`./../..` for non-[Bedrock](https://roots.io/bedrock/) installs)
 
 ### Build commands
 


### PR DESCRIPTION
using '/wp-content/themes/sage' will cause relative link issue when compiling assets if wordpress is installed in subdirectories. Changed to relative path './../..' ensures working on all installation.