### PR TITLE
Make 8.5.3 use the official Bootstrap 4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 8.5.3: August 18th, 2017
+* Popper.js now properly supports Bower ([#1953](https://github.com/roots/sage/pull/1953))
+
 ### 8.5.2: August 13th, 2017
 * Update to Bootstrap 4 Beta ([#1944](https://github.com/roots/sage/pull/1944))
 * Fix caption display ([#1878](https://github.com/roots/sage/pull/1878))

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Install Sage using Composer from your WordPress themes directory (replace `your-
 
 ```shell
 # @ example.com/site/web/app/themes/
-$ composer create-project roots/sage your-theme-name 8.5.2
+$ composer create-project roots/sage your-theme-name 8.5.3
 ```
 
 ## Theme setup

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -1,8 +1,10 @@
 @import "common/variables";
 
+// Manually import Bootstrap 4 as it doesn't support Bower any more
+@import "../../bower_components/bootstrap/scss/bootstrap.scss";
+
 // Automatically injected Bower dependencies via wiredep (never manually edit this block)
 // bower:scss
-@import "../../bower_components/bootstrap/scss/bootstrap.scss";
 // endbower
 
 @import "common/global";

--- a/bower.json
+++ b/bower.json
@@ -8,16 +8,6 @@
   "private": true,
   "dependencies": {
     "bootstrap": "git://github.com/twbs/bootstrap.git#v4.0.0-beta",
-    "popper.js": "https://unpkg.com/popper.js"
-  },
-  "overrides": {
-    "popper.js": {
-      "main": [
-        "./index.js"
-      ]
-    }
-  },
-  "resolutions": {
-    "popper.js": "e-tag:W/\"13b6b-1"
+    "popper.js": "^1.12.3"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "bootstrap": "git://github.com/twbs/bootstrap.git#v4.0.0-beta",
+    "bootstrap": "^4.0.0",
     "popper.js": "^1.12.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sage",
-  "version": "8.5.2",
+  "version": "8.5.3",
   "author": "Ben Word <ben@benword.com>",
   "homepage": "https://roots.io/sage/",
   "private": true,

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:         Sage Starter Theme
 Theme URI:          https://roots.io/sage/
 Description:        Sage is a WordPress starter theme. <a href="https://github.com/roots/sage">Contribute on GitHub</a>
-Version:            8.5.2
+Version:            8.5.3
 Author:             Roots
 Author URI:         https://roots.io/
 Text Domain:        sage


### PR DESCRIPTION
I got caught out by this today. Bootstrap 4 has dropped support for Bower (which is kinda deprecated).

So when the official, non-beta BS4 docs conflicted with the BS4-beta included in Sage 8.5.3, I updated my bower.json to use the official BS release.

This then broke the build because BS4 doesn't support Bower.

So hoping you'll pull this so others using Sage 8.5 don't get the same grief I did.

Thanks!