### PR TITLE
Remove jQuery Dependencies

### DIFF
--- a/resources/assets/scripts/customizer.js
+++ b/resources/assets/scripts/customizer.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 wp.customize('blogname', (value) => {
-  value.bind(to => $('.brand').text(to));
+  value.bind(to => querySelector('.brand').text(to));
 });

--- a/resources/assets/scripts/main.js
+++ b/resources/assets/scripts/main.js
@@ -21,4 +21,13 @@ const routes = new Router({
 });
 
 // Load Events
-jQuery(document).ready(() => routes.loadEvents());
+var callback = () => routes.loadEvents();
+
+if (
+  document.readyState === "complete" ||
+  (document.readyState !== "loading" && !document.documentElement.doScroll)
+) {
+  callback();
+} else {
+  document.addEventListener("DOMContentLoaded", callback);
+}


### PR DESCRIPTION
Removing jQuery dependency from main files since the rest of this is ES-2015 compatible

Document.readyState snippet added from this example:
https://www.sitepoint.com/jquery-document-ready-plain-javascript/#plainjavascriptreadyalternative