### PR TITLE
Changed inline @php directive to full form

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -10,7 +10,7 @@
     {!! get_search_form(false) !!}
   @endif
 
-  @while (have_posts()) @php(the_post())
+  @while (have_posts()) @php the_post() @endphp
     @include('partials.content-'.get_post_type())
   @endwhile
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,8 +1,8 @@
 <!doctype html>
-<html @php(language_attributes())>
+<html @php language_attributes() @endphp>
   @include('partials.head')
-  <body @php(body_class())>
-    @php(do_action('get_header'))
+  <body @php body_class() @endphp>
+    @php do_action('get_header') @endphp
     @include('partials.header')
     <div class="wrap container" role="document">
       <div class="content">
@@ -16,8 +16,8 @@
         @endif
       </div>
     </div>
-    @php(do_action('get_footer'))
+    @php do_action('get_footer') @endphp
     @include('partials.footer')
-    @php(wp_footer())
+    @php wp_footer() @endphp
   </body>
 </html>

--- a/resources/views/page.blade.php
+++ b/resources/views/page.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 
 @section('content')
-  @while(have_posts()) @php(the_post())
+  @while(have_posts()) @php the_post() @endphp
     @include('partials.page-header')
     @include('partials.content-page')
   @endwhile

--- a/resources/views/partials/comments.blade.php
+++ b/resources/views/partials/comments.blade.php
@@ -34,5 +34,5 @@ if (post_password_required()) {
     </div>
   @endif
 
-  @php(comment_form())
+  @php comment_form() @endphp
 </section>

--- a/resources/views/partials/content-page.blade.php
+++ b/resources/views/partials/content-page.blade.php
@@ -1,2 +1,2 @@
-@php(the_content())
+@php the_content() @endphp
 {!! wp_link_pages(['echo' => 0, 'before' => '<nav class="page-nav"><p>' . __('Pages:', 'sage'), 'after' => '</p></nav>']) !!}

--- a/resources/views/partials/content-search.blade.php
+++ b/resources/views/partials/content-search.blade.php
@@ -1,4 +1,4 @@
-<article @php(post_class())>
+<article @php post_class() @endphp>
   <header>
     <h2 class="entry-title"><a href="{{ get_permalink() }}">{{ get_the_title() }}</a></h2>
     @if (get_post_type() === 'post')
@@ -6,6 +6,6 @@
     @endif
   </header>
   <div class="entry-summary">
-    @php(the_excerpt())
+    @php the_excerpt() @endphp
   </div>
 </article>

--- a/resources/views/partials/content-single.blade.php
+++ b/resources/views/partials/content-single.blade.php
@@ -1,13 +1,13 @@
-<article @php(post_class())>
+<article @php post_class() @endphp>
   <header>
     <h1 class="entry-title">{{ get_the_title() }}</h1>
     @include('partials/entry-meta')
   </header>
   <div class="entry-content">
-    @php(the_content())
+    @php the_content() @endphp
   </div>
   <footer>
     {!! wp_link_pages(['echo' => 0, 'before' => '<nav class="page-nav"><p>' . __('Pages:', 'sage'), 'after' => '</p></nav>']) !!}
   </footer>
-  @php(comments_template('/partials/comments.blade.php'))
+  @php comments_template('/partials/comments.blade.php') @endphp
 </article>

--- a/resources/views/partials/content.blade.php
+++ b/resources/views/partials/content.blade.php
@@ -1,9 +1,9 @@
-<article @php(post_class())>
+<article @php post_class() @endphp>
   <header>
     <h2 class="entry-title"><a href="{{ get_permalink() }}">{{ get_the_title() }}</a></h2>
     @include('partials/entry-meta')
   </header>
   <div class="entry-summary">
-    @php(the_excerpt())
+    @php the_excerpt() @endphp
   </div>
 </article>

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -1,5 +1,5 @@
 <footer class="content-info">
   <div class="container">
-    @php(dynamic_sidebar('sidebar-footer'))
+    @php dynamic_sidebar('sidebar-footer') @endphp
   </div>
 </footer>

--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -2,5 +2,5 @@
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  @php(wp_head())
+  @php wp_head() @endphp
 </head>

--- a/resources/views/search.blade.php
+++ b/resources/views/search.blade.php
@@ -10,7 +10,7 @@
     {!! get_search_form(false) !!}
   @endif
 
-  @while(have_posts()) @php(the_post())
+  @while(have_posts()) @php the_post() @endphp
     @include('partials.content-search')
   @endwhile
 

--- a/resources/views/single.blade.php
+++ b/resources/views/single.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 
 @section('content')
-  @while(have_posts()) @php(the_post())
+  @while(have_posts()) @php the_post() @endphp
     @include('partials.content-single-'.get_post_type())
   @endwhile
 @endsection

--- a/resources/views/template-custom.blade.php
+++ b/resources/views/template-custom.blade.php
@@ -5,7 +5,7 @@
 @extends('layouts.app')
 
 @section('content')
-  @while(have_posts()) @php(the_post())
+  @while(have_posts()) @php the_post() @endphp
     @include('partials.page-header')
     @include('partials.content-page')
   @endwhile


### PR DESCRIPTION
According to https://github.com/roots/sage/issues/2012 issue, Laravel 5.5 dropped support for inline `@php` directive like `@php()`. On this PR I changed every inline to full form. I've already reproduce the issue on my sage-woo fork.