### PR TITLE
Auto-detect proxyUrl scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Auto-detect `proxyUrl` scheme ([#2062](https://github.com/roots/sage/pull/2062))
 * Bump to Laravel 5.6 ([#2061](https://github.com/roots/sage/pull/2061))
 * Update to Boostrap 4.1.0 ([#2056](https://github.com/roots/sage/pull/2056))
 * Change inline `@php` directive to full form ([#2042](https://github.com/roots/sage/pull/2042))

--- a/resources/assets/build/webpack.config.watch.js
+++ b/resources/assets/build/webpack.config.watch.js
@@ -11,6 +11,8 @@ const target = process.env.DEVURL || config.devUrl;
  */
 if (url.parse(target).protocol === 'https:') {
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+
+  config.proxyUrl = config.proxyUrl.replace('http:', 'https:');
 }
 
 module.exports = {


### PR DESCRIPTION
sage-installer doesn't set `proxyUrl` to `https` if you provided an `https` URL for your `proxyUrl`, resulting in issues with browsersync sessions

rather than forcing it in sage-installer, here we're detecting which scheme to use based on `devUrl` and overriding it for `proxyUrl`