### PR TITLE
Make template() compatible with wp admin

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -52,7 +52,7 @@ function config($key = null, $default = null)
  */
 function template($file, $data = [])
 {
-    if (remove_action('wp_head', 'wp_enqueue_scripts', 1)) {
+    if (!is_admin() && remove_action('wp_head', 'wp_enqueue_scripts', 1)) {
         wp_enqueue_scripts();
     }
 


### PR DESCRIPTION
This prevents template() from enqueuing styles and scripts intended for the front end, when used in the admin.