### PR TITLE
Add uglifyjs plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
     ]
   },
   "rules": {
-    "no-console": process.env.NODE_ENV === 'production' ? 2 : 0,
+    "no-console": 0,
     "comma-dangle": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "scripts": {
     "build": "webpack --progress --config resources/assets/build/webpack.config.js",
-    "build:production": "webpack --progress -p --config resources/assets/build/webpack.config.js",
+    "build:production": "webpack --env.production --progress --config resources/assets/build/webpack.config.js",
     "build:profile": "webpack --progress --profile --json --config resources/assets/build/webpack.config.js",
     "start": "webpack --hide-modules --watch --config resources/assets/build/webpack.config.js",
     "rmdist": "rimraf dist",
@@ -94,6 +94,7 @@
     "stylelint": "^8.4.0",
     "stylelint-config-standard": "~18.2.0",
     "stylelint-webpack-plugin": "^0.10.1",
+    "uglifyjs-webpack-plugin": "^1.2.5",
     "url-loader": "^0.6.2",
     "webpack": "~3.10.0",
     "webpack-assets-manifest": "^1.0.0",

--- a/resources/assets/build/webpack.config.optimize.js
+++ b/resources/assets/build/webpack.config.optimize.js
@@ -2,6 +2,7 @@
 
 const { default: ImageminPlugin } = require('imagemin-webpack-plugin');
 const imageminMozjpeg = require('imagemin-mozjpeg');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 
 const config = require('./config');
 
@@ -16,6 +17,15 @@ module.exports = {
       },
       plugins: [imageminMozjpeg({ quality: 75 })],
       disable: (config.enabled.watcher),
+    }),
+    new UglifyJsPlugin({
+      uglifyOptions: {
+        ecma: 8,
+        compress: {
+          warnings: true,
+          drop_console: true,
+        },
+      },
     }),
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7914,7 +7914,7 @@ uglifyjs-webpack-plugin@^0.4.6:
     uglify-js "^2.8.29"
     webpack-sources "^1.0.1"
 
-uglifyjs-webpack-plugin@^1.2.4:
+uglifyjs-webpack-plugin@^1.2.4, uglifyjs-webpack-plugin@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.5.tgz#2ef8387c8f1a903ec5e44fa36f9f3cbdcea67641"
   dependencies:


### PR DESCRIPTION
Simply use UglifyJs plugin instead of Webpack built-in version which allows us to configure it. I'm including one useful feature to drop console.log statements to avoid eslint errors on `build:production`

Related to discourse discussion: https://discourse.roots.io/t/uglifyjs-error-on-production-build/12419/4?u=jasonbaciulis