### PR TITLE
Proposal: more compatible comments template

### DIFF
--- a/resources/views/partials/comments.blade.php
+++ b/resources/views/partials/comments.blade.php
@@ -5,13 +5,13 @@ if (post_password_required()) {
 @endphp
 
 <section id="comments" class="comments">
-  @if (have_comments())
+  @if ((int)get_comments_number() > 0)
     <h2>
       {!! sprintf(_nx('One response to &ldquo;%2$s&rdquo;', '%1$s responses to &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'sage'), number_format_i18n(get_comments_number()), '<span>' . get_the_title() . '</span>') !!}
     </h2>
 
     <ol class="comment-list">
-      {!! wp_list_comments(['style' => 'ol', 'short_ping' => true]) !!}
+      {!! wp_list_comments(['style' => 'ol', 'short_ping' => true], get_comments([ 'post_id' => get_the_ID(), 'status' => 'approve'])) !!}
     </ol>
 
     @if (get_comment_pages_count() > 1 && get_option('page_comments'))


### PR DESCRIPTION
Use of `get_comments_number()` instead of `have_comments()`, because the last one as per documentation:

> will always return "false" until after comments_template has been called. If you need to check for comments before calling comments_template, use get_comments_number instead
[Source](https://codex.wordpress.org/Function_Reference/have_comments)

I don't know why in my project calling `include('partials.comments')` always return false.

In that kind of situation, is also necessary to pass `get_comments` as second argument to `wp_list_comments`