### PR TITLE
Proposal: Set removeViewBox to 'false' in webpack's optimization settings

### DIFF
--- a/resources/assets/build/webpack.config.optimize.js
+++ b/resources/assets/build/webpack.config.optimize.js
@@ -12,7 +12,11 @@ module.exports = {
       gifsicle: { optimizationLevel: 3 },
       pngquant: { quality: '65-90', speed: 4 },
       svgo: {
-        plugins: [{ removeUnknownsAndDefaults: false }, { cleanupIDs: false }],
+        plugins: [
+          { removeUnknownsAndDefaults: false },
+          { cleanupIDs: false },
+          { removeViewBox: false }
+        ],
       },
       plugins: [imageminMozjpeg({ quality: 75 })],
       disable: (config.enabled.watcher),

--- a/resources/assets/build/webpack.config.optimize.js
+++ b/resources/assets/build/webpack.config.optimize.js
@@ -15,7 +15,7 @@ module.exports = {
         plugins: [
           { removeUnknownsAndDefaults: false },
           { cleanupIDs: false },
-          { removeViewBox: false }
+          { removeViewBox: false },
         ],
       },
       plugins: [imageminMozjpeg({ quality: 75 })],


### PR DESCRIPTION
Disable removal of the SVG viewBox by default to improve compatibility. See this Discourse thread: https://discourse.roots.io/t/svg-size-change-upon-yarn-build-production/12320