### PR TITLE
Enable Sass comments and run prefixing before minification

### DIFF
--- a/resources/assets/build/postcss.config.js
+++ b/resources/assets/build/postcss.config.js
@@ -8,8 +8,8 @@ module.exports = ({ file, options }) => {
   return {
     parser: options.enabled.optimize ? 'postcss-safe-parser' : undefined,
     plugins: {
-      cssnano: options.enabled.optimize ? cssnanoConfig : false,
       autoprefixer: true,
+      cssnano: options.enabled.optimize ? cssnanoConfig : false,
     },
   };
 };

--- a/resources/assets/build/webpack.config.js
+++ b/resources/assets/build/webpack.config.js
@@ -89,7 +89,12 @@ let webpackConfig = {
               },
             },
             { loader: 'resolve-url', options: { sourceMap: config.enabled.sourceMaps } },
-            { loader: 'sass', options: { sourceMap: config.enabled.sourceMaps } },
+            {
+              loader: 'sass', options: {
+                sourceMap: config.enabled.sourceMaps,
+                sourceComments: true
+              }
+            },
           ],
         }),
       },

--- a/resources/assets/build/webpack.config.js
+++ b/resources/assets/build/webpack.config.js
@@ -92,8 +92,8 @@ let webpackConfig = {
             {
               loader: 'sass', options: {
                 sourceMap: config.enabled.sourceMaps,
-                sourceComments: true
-              }
+                sourceComments: true,
+              },
             },
           ],
         }),


### PR DESCRIPTION
I was looking into a fix for #2077 and here’s what I discovered:

- `cssnano` was not the issue with the above mentioned issue the desired functionality works perfectly when using normal CSS instead of Sass.
- Sass removes the source comments by default.
  - So even disabling `cssnano` completely still resulted with the same issue.
- [Autoprefixer requires `/*! autoprefixer: off */` in Sass and Less](https://github.com/postcss/autoprefixer#control-comments).

### The problem:

- When processing Sass, comments are removed before the PostCSS plugins are processed.
  - PostCSS plugins (i.e. Autoprefixer, Purgecss) often use comments for processing so we need them to be there when that processing takes place.
  - We still want `cssnano`’s `discardComments` set to `removeAll: true` since we don’t want any comments in the production built code.

### This pull request:

- Enables the source comments in Sass.
  - This is temporary since they will be removed by minification.
- Moves the autoprefixing task before minification.
  - ~I do not know the side effects of doing this. I am actively testing for anything undesirable.~ Everything seems to run fine from my tests. I do know that cssnano doesn’t remove prefixes as of `4.0.0-rc.0`, so there should be no issues there.

### Examples

#### Before as described in #2077

Input:

```css
image {
  /* autoprefixer: off */
  clip-path: url(#imagemask);
}

```

Output:

```css
image{-webkit-clip-path:url(#imagemask);clip-path:url(#imagemask)}
```

#### With the important comment and discardComments removed

Input:

```css
image {
  /*! autoprefixer: off */
  clip-path: url(#imagemask);
}
```

Output:

```css
image{
  /*! autoprefixer: off */clip-path:url(#imagemask)}
```

This works but we don’t want the comment in there.

#### With this PR

Input:

```css
image {
  /*! autoprefixer: off */
  clip-path: url(#imagemask);
}
```

Output:

```css
image{clip-path:url(#imagemask)}
```

Perfect!

### Related

- #2077 
- https://discourse.roots.io/t/removing-unused-css-with-purgecss-uncss/11586/13?u=knowler