### PR TITLE
Dispatch event when firing routes

### DIFF
--- a/resources/assets/scripts/util/Router.js
+++ b/resources/assets/scripts/util/Router.js
@@ -25,6 +25,14 @@ class Router {
    * @param {string} [arg] Any custom argument to be passed to the event.
    */
   fire(route, event = 'init', arg) {
+    document.dispatchEvent(new CustomEvent('routed', {
+      bubbles: true,
+      detail: {
+        route,
+        fn
+      }
+    }));
+    
     const fire = route !== '' && this.routes[route] && typeof this.routes[route][event] === 'function';
     if (fire) {
       this.routes[route][event](arg);

--- a/resources/assets/scripts/util/Router.js
+++ b/resources/assets/scripts/util/Router.js
@@ -29,8 +29,8 @@ class Router {
       bubbles: true,
       detail: {
         route,
-        fn: event
-      }
+        fn: event,
+      },
     }));
     
     const fire = route !== '' && this.routes[route] && typeof this.routes[route][event] === 'function';

--- a/resources/assets/scripts/util/Router.js
+++ b/resources/assets/scripts/util/Router.js
@@ -29,7 +29,7 @@ class Router {
       bubbles: true,
       detail: {
         route,
-        fn
+        fn: event
       }
     }));
     


### PR DESCRIPTION
It is especially neat when importing the scripts from the parent theme in a child theme. In one of my themes I do it like this:

```js
// routes.js
export default {
    home: {
      init() {
        console.log('Home route fired.')
      }
    }
}
```

  ```js
// main.js
/**
 * Parent Themes Script
 */
import '../../../../core-theme/resources/assets/scripts/main';

/**
 * Internal modules
 */
import routes from './routes'

/**
 * Hook in to the parent themes router
 */
document.addEventListener('routed', e => {
  let route = e.detail.route,
    fn = e.detail.fn;

  if (routes[route] && typeof routes[route][fn] === 'function') {
    routes[route][fn]();
  }
});
```