### PR TITLE
Add support for preset specific Webpack config

### DIFF
--- a/resources/assets/build/webpack.config.js
+++ b/resources/assets/build/webpack.config.js
@@ -2,6 +2,7 @@
 
 const webpack = require('webpack');
 const merge = require('webpack-merge');
+const desire = require('./util/desire');
 const CleanPlugin = require('clean-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const StyleLintPlugin = require('stylelint-webpack-plugin');
@@ -213,4 +214,4 @@ if (config.enabled.watcher) {
   webpackConfig = merge(webpackConfig, require('./webpack.config.watch'));
 }
 
-module.exports = webpackConfig;
+module.exports = merge(webpackConfig, desire(`${__dirname}/webpack.config.preset`));

--- a/resources/assets/build/webpack.config.js
+++ b/resources/assets/build/webpack.config.js
@@ -2,13 +2,13 @@
 
 const webpack = require('webpack');
 const merge = require('webpack-merge');
-const desire = require('./util/desire');
 const CleanPlugin = require('clean-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const StyleLintPlugin = require('stylelint-webpack-plugin');
 const CopyGlobsPlugin = require('copy-globs-webpack-plugin');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 
+const desire = require('./util/desire');
 const config = require('./config');
 
 const assetsFilenames = (config.enabled.cacheBusting) ? config.cacheBusting : '[name]';


### PR DESCRIPTION
This checks for a `webpack.config.preset.js` file in the `build` directory. This is a useful feature for the installer, giving us the ability to add preset specific modifications to the `webpack.config.js` without needing to make a copy of it in the `sage-installer` repo.

h/t to @QWp6t and @mmirus 