### PR TITLE
Use better merge method for Webpack Preset config

### DIFF
--- a/resources/assets/build/webpack.config.js
+++ b/resources/assets/build/webpack.config.js
@@ -214,4 +214,6 @@ if (config.enabled.watcher) {
   webpackConfig = merge(webpackConfig, require('./webpack.config.watch'));
 }
 
-module.exports = merge(webpackConfig, desire(`${__dirname}/webpack.config.preset`));
+module.exports = merge.smartStrategy({
+  'module.loaders': 'replace',
+})(webpackConfig, desire(`${__dirname}/webpack.config.preset`));


### PR DESCRIPTION
Using `merge.smartStrategy` with `'module.loaders' = 'replace'` to load the preset config allows presets to override the the default webpack config. This is necessary for [the coming Tailwind preset](https://github.com/roots/sage-installer/pull/22) which requires `resolve-url-loader` and source maps to be disabled.