### PR TITLE
Fix missing comment-reply JS

### DIFF
--- a/app/setup.php
+++ b/app/setup.php
@@ -13,6 +13,10 @@ use Roots\Sage\Template\BladeProvider;
 add_action('wp_enqueue_scripts', function () {
     wp_enqueue_style('sage/main.css', asset_path('styles/main.css'), false, null);
     wp_enqueue_script('sage/main.js', asset_path('scripts/main.js'), ['jquery'], null, true);
+
+    if (is_single() && comments_open() && get_option('thread_comments')) {
+      wp_enqueue_script('comment-reply');
+    }
 }, 100);
 
 /**


### PR DESCRIPTION
Fixes [this error (missing comment-reply JS)](https://discourse.roots.io/t/missing-comment-reply-js-out-of-the-box/12948) by reverting commit [d217ba6](https://github.com/roots/sage/commit/d217ba6).