### PR TITLE
Add WooCommerce support

### DIFF
--- a/app/woocommerce.php
+++ b/app/woocommerce.php
@@ -13,10 +13,10 @@ if (defined('WC_ABSPATH')) {
             : locate_template('woocommerce/' . str_replace(WC_ABSPATH . 'templates/', '', $template)) ?: $template;
     }, 100, 1);
 
-    add_filter('wc_get_template_part', function ($template, $slug, $name) {
+    add_filter('wc_get_template_part', function ($template) {
         $theme_template = locate_template('woocommerce/' . str_replace(WC_ABSPATH . 'templates/', '', $template));
         return $theme_template ? template_path($theme_template) : $template;
-    }, 100, 3);
+    }, 100, 1);
 
     add_filter('wc_get_template', function ($template, $template_name, $args) {
         $theme_template = locate_template('woocommerce/' . $template_name);

--- a/app/woocommerce.php
+++ b/app/woocommerce.php
@@ -8,19 +8,13 @@ if (defined('WC_ABSPATH')) {
     });
 
     add_filter('template_include', function ($template) {
-        if (strpos($template, WC_ABSPATH) === 0) {
-            $check_template = 'woocommerce/' . str_replace(WC_ABSPATH . 'templates/', '', $template);
-            $template = locate_template($check_template) ?: $template;
-        }
-        return $template;
+        return strpos($template, WC_ABSPATH) === -1
+            ? $template
+            : locate_template('woocommerce/' . str_replace(WC_ABSPATH . 'templates/', '', $template)) ?: $template;
     }, 100, 1);
 
     add_filter('wc_get_template_part', function ($template, $slug, $name) {
-        $theme_template = locate_template([
-            'woocommerce/' . str_replace(WC_ABSPATH . 'templates/', '', $template),
-            'woocommerce/' . $slug . '-' . $name,
-            'woocommerce/' . $name,
-        ]);
+        $theme_template = locate_template('woocommerce/' . str_replace(WC_ABSPATH . 'templates/', '', $template));
         return $theme_template ? template_path($theme_template) : $template;
     }, 100, 3);
 

--- a/app/woocommerce.php
+++ b/app/woocommerce.php
@@ -2,14 +2,15 @@
 
 namespace App;
 
-if(defined('WC_ABSPATH')) {
+if (defined('WC_ABSPATH')) {
     add_action('after_setup_theme', function () {
         add_theme_support('woocommerce');
     });
 
     add_filter('template_include', function ($template) {
-        if(strpos($template, WC_ABSPATH) === 0) {
-            $template = locate_template('woocommerce/' . str_replace(WC_ABSPATH . 'templates/', '', $template)) ?: $template;
+        if (strpos($template, WC_ABSPATH) === 0) {
+            $check_template = 'woocommerce/' . str_replace(WC_ABSPATH . 'templates/', '', $template);
+            $template = locate_template($check_template) ?: $template;
         }
         return $template;
     }, 100, 1);

--- a/app/woocommerce.php
+++ b/app/woocommerce.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App;
+
+if(defined('WC_ABSPATH')) {
+    add_action('after_setup_theme', function () {
+        add_theme_support('woocommerce');
+    });
+
+    add_filter('template_include', function ($template) {
+        if(strpos($template, WC_ABSPATH) === 0) {
+            $template = locate_template('woocommerce/' . str_replace(WC_ABSPATH . 'templates/', '', $template)) ?: $template;
+        }
+        return $template;
+    }, 100, 1);
+
+    add_filter('wc_get_template_part', function ($template, $slug, $name) {
+        $theme_template = locate_template([
+            'woocommerce/' . str_replace(WC_ABSPATH . 'templates/', '', $template),
+            'woocommerce/' . $slug . '-' . $name,
+            'woocommerce/' . $name,
+        ]);
+        return $theme_template ? template_path($theme_template) : $template;
+    }, 100, 3);
+
+    add_filter('wc_get_template', function ($template, $template_name, $args) {
+        $theme_template = locate_template('woocommerce/' . $template_name);
+        return $theme_template ? template_path($theme_template, $args) : $template;
+    }, 100, 3);
+}

--- a/resources/functions.php
+++ b/resources/functions.php
@@ -58,7 +58,7 @@ array_map(function ($file) use ($sage_error) {
     if (!locate_template($file, true, true)) {
         $sage_error(sprintf(__('Error locating <code>%s</code> for inclusion.', 'sage'), $file), 'File not found');
     }
-}, ['helpers', 'setup', 'filters', 'admin']);
+}, ['helpers', 'setup', 'filters', 'admin', 'woocommerce']);
 
 /**
  * Here's what's happening with these hooks:


### PR DESCRIPTION
Making WooCommerce work in Sage can be a hard task to do right for a beginner. I tried to find a way, and this is what I came with. I think that WooCommerce is such a popular plugin that it should be supported out-of-the-box. I've created the pull request with an as little footprint as possible.

With this pull request, you can easily overwrite any WooCommerce template by placing it into `/resources/views/woocommerce` folder, and it just works. You can even use controllers to inject variables you need as usual. Hooks are called only if WooCommerce is activated, checking the `WC_ABSPATH ` constant defined.
