### PR TITLE
Change language_attributes() to get_language_attributes()

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!doctype html>
-<html @php language_attributes() @endphp>
+<html {{ get_language_attributes() }}>
   @include('partials.head')
   <body @php body_class() @endphp>
     @php do_action('get_header') @endphp


### PR DESCRIPTION
https://developer.wordpress.org/reference/functions/get_language_attributes/
https://developer.wordpress.org/reference/functions/language_attributes/#source

```
craig [5:23 PM]
PRs accepted
```