### PR TITLE
Add searchform partial and function to replace default WordPress functionality

### DIFF
--- a/app/filters.php
+++ b/app/filters.php
@@ -84,12 +84,12 @@ add_filter('get_search_form', function () {
 /**
  * Collect data for searchform.
  */
- add_filter('sage/template/app/data', function ($data) {
-  return $data + [
-    'sf_action' => esc_url(home_url('/')),
-    'sf_screen_reader_text' => _x('Search for:', 'label', 'sage'),
-    'sf_placeholder' => esc_attr_x('Search &hellip;', 'placeholder', 'sage'),
-    'sf_current_query' => get_search_query(),
-    'sf_submit_text' => esc_attr_x('Search', 'submit button', 'sage'),
-  ];
+add_filter('sage/template/app/data', function ($data) {
+    return $data + [
+        'sf_action' => esc_url(home_url('/')),
+        'sf_screen_reader_text' => _x('Search for:', 'label', 'sage'),
+        'sf_placeholder' => esc_attr_x('Search &hellip;', 'placeholder', 'sage'),
+        'sf_current_query' => get_search_query(),
+        'sf_submit_text' => esc_attr_x('Search', 'submit button', 'sage'),
+    ];
 });

--- a/app/filters.php
+++ b/app/filters.php
@@ -84,11 +84,12 @@ add_filter('get_search_form', function () {
 /**
  * Collect data for searchform.
  */
-add_filter('sage/template/app/data', function ($data) {
-    $data['sf_action'] = esc_url(home_url('/'));
-    $data['sf_screen_reader_text'] = _x('Search for:', 'label', 'sage');
-    $data['sf_placeholder'] = esc_attr_x('Search &hellip;', 'placeholder', 'sage');
-    $data['sf_current_query'] = get_search_query();
-    $data['sf_submit_text'] = esc_attr_x('Search', 'submit button', 'sage');
-    return $data;
+ add_filter('sage/template/app/data', function ($data) {
+  return $data + [
+    'sf_action' => esc_url(home_url('/')),
+    'sf_screen_reader_text' => _x('Search for:', 'label', 'sage'),
+    'sf_placeholder' => esc_attr_x('Search &hellip;', 'placeholder', 'sage'),
+    'sf_current_query' => get_search_query(),
+    'sf_submit_text' => esc_attr_x('Search', 'submit button', 'sage'),
+  ];
 });

--- a/app/filters.php
+++ b/app/filters.php
@@ -13,6 +13,11 @@ add_filter('body_class', function (array $classes) {
         }
     }
 
+    /** Add a global class to everything.
+     *  We want it to come first, so stuff its filter does can be overridden.
+     */
+    array_unshift($classes, 'app');
+
     /** Add class if sidebar is active */
     if (display_sidebar()) {
         $classes[] = 'sidebar-primary';
@@ -74,4 +79,16 @@ add_filter('comments_template', function ($comments_template) {
  */
 add_filter('get_search_form', function () {
     return template('partials.searchform');
+});
+
+/**
+ * Collect data for searchform.
+ */
+add_filter('sage/template/app/data', function ($data) {
+    $data['sf_action'] = esc_url(home_url('/'));
+    $data['sf_screen_reader_text'] = _x('Search for:', 'label', 'sage');
+    $data['sf_placeholder'] = esc_attr_x('Search &hellip;', 'placeholder', 'sage');
+    $data['sf_current_query'] = get_search_query();
+    $data['sf_submit_text'] = esc_attr_x('Search', 'submit button', 'sage');
+    return $data;
 });

--- a/app/filters.php
+++ b/app/filters.php
@@ -68,3 +68,10 @@ add_filter('comments_template', function ($comments_template) {
     );
     return template_path(locate_template(["views/{$comments_template}", $comments_template]) ?: $comments_template);
 }, 100);
+
+/**
+ * Render WordPress searchform using Blade
+ */
+add_filter('get_search_form', function () {
+    return template('partials.searchform');
+});

--- a/resources/views/partials/searchform.blade.php
+++ b/resources/views/partials/searchform.blade.php
@@ -1,7 +1,7 @@
-<form role="search" method="get" class="search-form" action="{{ esc_url(home_url('/')) }}">
+<form role="search" method="get" class="search-form" action="{{ $sf_action }}">
   <label>
-    <span class="screen-reader-text">{{ _x('Search for:', 'label', 'sage') }}</span>
-    <input type="search" class="search-field" placeholder="{!! esc_attr_x('Search &hellip;', 'placeholder', 'sage') !!}" value="{{ get_search_query() }}" name="s">
+    <span class="screen-reader-text">{{ $sf_screen_reader_text }}</span>
+    <input type="search" class="search-field" placeholder="{!! $sf_placeholder !!}" value="{{ $sf_current_query }}" name="s">
   </label>
-  <input type="submit" class="search-submit" value="{{ esc_attr_x('Search', 'submit button', 'sage') }}">
+  <input type="submit" class="search-submit" value="{{ $sf_submit_text }}">
 </form>

--- a/resources/views/partials/searchform.blade.php
+++ b/resources/views/partials/searchform.blade.php
@@ -1,7 +1,7 @@
-<form role="search" method="get" class="search-form" action="{{ esc_url(home_url( '/') ) }}">
+<form role="search" method="get" class="search-form" action="{{ esc_url(home_url('/')) }}">
   <label>
-    <span class="screen-reader-text">{{ _x('Search for:', 'label') }}</span>
-    <input type="search" class="search-field" placeholder="{!! esc_attr_x('Search &hellip;', 'placeholder') !!}" value="{{ get_search_query() }}" name="s">
+    <span class="screen-reader-text">{{ _x('Search for:', 'label', 'sage') }}</span>
+    <input type="search" class="search-field" placeholder="{!! esc_attr_x('Search &hellip;', 'placeholder', 'sage') !!}" value="{{ get_search_query() }}" name="s">
   </label>
-  <input type="submit" class="search-submit" value="{{ esc_attr_x('Search', 'submit button') }}">
+  <input type="submit" class="search-submit" value="{{ esc_attr_x('Search', 'submit button', 'sage') }}">
 </form>

--- a/resources/views/partials/searchform.blade.php
+++ b/resources/views/partials/searchform.blade.php
@@ -1,0 +1,7 @@
+<form role="search" method="get" class="search-form" action="{{ esc_url( home_url( '/' ) ) }}">
+  <label>
+    <span class="screen-reader-text">{{ _x( 'Search for:', 'label' ) }}</span>
+    <input type="search" class="search-field" placeholder="{!! esc_attr_x( 'Search &hellip;', 'placeholder' ) !!}" value="{{ get_search_query() }}" name="s" />
+  </label>
+  <input type="submit" class="search-submit" value="{{ esc_attr_x( 'Search', 'submit button' ) }}" />
+</form>

--- a/resources/views/partials/searchform.blade.php
+++ b/resources/views/partials/searchform.blade.php
@@ -1,7 +1,7 @@
-<form role="search" method="get" class="search-form" action="{{ esc_url( home_url( '/' ) ) }}">
+<form role="search" method="get" class="search-form" action="{{ esc_url(home_url( '/') ) }}">
   <label>
-    <span class="screen-reader-text">{{ _x( 'Search for:', 'label' ) }}</span>
-    <input type="search" class="search-field" placeholder="{!! esc_attr_x( 'Search &hellip;', 'placeholder' ) !!}" value="{{ get_search_query() }}" name="s" />
+    <span class="screen-reader-text">{{ _x('Search for:', 'label') }}</span>
+    <input type="search" class="search-field" placeholder="{!! esc_attr_x('Search &hellip;', 'placeholder') !!}" value="{{ get_search_query() }}" name="s">
   </label>
-  <input type="submit" class="search-submit" value="{{ esc_attr_x( 'Search', 'submit button' ) }}" />
+  <input type="submit" class="search-submit" value="{{ esc_attr_x('Search', 'submit button') }}">
 </form>


### PR DESCRIPTION
Inspired by this thread:
https://discourse.roots.io/t/custom-search-form/9079

The WordPress searchform, and the ability to customize it, is basic WP functionality that Sage unintentionally breaks. This PR predictably replaces the WP default template with a Blade partial, much like the the comments partials we already ship, letting users use [get_search_form()](https://developer.wordpress.org/reference/functions/get_search_form/) as normal.