### PR TITLE
Move comments functions and data to filter

### DIFF
--- a/app/filters.php
+++ b/app/filters.php
@@ -93,3 +93,19 @@ add_filter('sage/template/app/data', function ($data) {
         'sf_submit_text' => esc_attr_x('Search', 'submit button', 'sage'),
     ];
 });
+
+/**
+ * Collect data for comments.
+ */
+add_filter('sage/template/app/data', function ($data) {
+    return $data + [
+    'password_required' => post_password_required(),
+    'has_comments' => have_comments(),
+    'comments_title' => sprintf(_nx('One response to &ldquo;%2$s&rdquo;', '%1$s responses to &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'sage'), number_format_i18n(get_comments_number()), '<span>' . get_the_title() . '</span>'),
+    'comments_list' => wp_list_comments(['style' => 'ol', 'short_ping' => true]),
+    'show_comments' => get_comment_pages_count() > 1 && get_option('page_comments'),
+    'previous_comments_link' => (get_previous_comments_link()) ? get_previous_comments_link(__('&larr; Older comments', 'sage')) : null,
+    'next_comments_link' => (get_next_comments_link()) ? get_next_comments_link(__('&larr; Newer comments', 'sage')) : null,
+    'comments_closed' => (!comments_open() && get_comments_number() != '0' && post_type_supports(get_post_type(), 'comments')) ? true : false,
+];
+});

--- a/resources/views/partials/comments.blade.php
+++ b/resources/views/partials/comments.blade.php
@@ -1,34 +1,30 @@
-@php
-if (post_password_required()) {
-  return;
-}
-@endphp
+@if (!$password_required)
 
 <section id="comments" class="comments">
-  @if (have_comments())
+  @if ($has_comments)
     <h2>
-      {!! sprintf(_nx('One response to &ldquo;%2$s&rdquo;', '%1$s responses to &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'sage'), number_format_i18n(get_comments_number()), '<span>' . get_the_title() . '</span>') !!}
+      {!! $comments_title !!}
     </h2>
 
     <ol class="comment-list">
-      {!! wp_list_comments(['style' => 'ol', 'short_ping' => true]) !!}
+      {!! $comments_list !!}
     </ol>
 
-    @if (get_comment_pages_count() > 1 && get_option('page_comments'))
+    @if ($show_comments)
       <nav>
         <ul class="pager">
-          @if (get_previous_comments_link())
-            <li class="previous">@php previous_comments_link(__('&larr; Older comments', 'sage')) @endphp</li>
+          @if ($previous_comments_link)
+            <li class="previous">{!! $previous_comments_link !!}</li>
           @endif
-          @if (get_next_comments_link())
-            <li class="next">@php next_comments_link(__('Newer comments &rarr;', 'sage')) @endphp</li>
+          @if ($next_comments_link)
+            <li class="next">{!! $next_comments_link !!}</li>
           @endif
         </ul>
       </nav>
     @endif
   @endif
 
-  @if (!comments_open() && get_comments_number() != '0' && post_type_supports(get_post_type(), 'comments'))
+  @if ($comments_closed)
     <div class="alert alert-warning">
       {{ __('Comments are closed.', 'sage') }}
     </div>
@@ -36,3 +32,5 @@ if (post_password_required()) {
 
   @php comment_form() @endphp
 </section>
+
+@endif


### PR DESCRIPTION
All this does is move the existing comments partial functions and data to a filter, the same way we just did with the searchform.

I haven't done any work to simplify this template, or even think clearly about whether this implementation makes sense; I wanted to get the conversation started. If we're doing it this way with searchform, we should do it this way with comments.