### PR TITLE
UglifyJs: Change the ecma option from 8 to 5

### DIFF
--- a/resources/assets/build/webpack.config.optimize.js
+++ b/resources/assets/build/webpack.config.optimize.js
@@ -24,7 +24,7 @@ module.exports = {
     }),
     new UglifyJsPlugin({
       uglifyOptions: {
-        ecma: 8,
+        ecma: 5,
         compress: {
           warnings: true,
           drop_console: true,


### PR DESCRIPTION
# Problem:
I recently had a problem with the [ecma option of UglifyJs](https://github.com/mishoo/UglifyJS2/tree/harmony#minify-options) being set to `8`.

One of my packages was using [bn.js](https://github.com/indutny/bn.js/) as a dependency and [this block of code right here](https://github.com/indutny/bn.js/blob/e69c617b3297b99aca429f30842e27979ef9beb5/lib/bn.js#L2600-L2604) was compiled to `return{a,b:f,gcd:i.iushln(c)}}` and of course the `a`  threw an `SCRIPT1003: Expected ':'` error in Internet Explorer because it doesn't support the new [EcmaScript 6 Property Shorthand syntax](http://es6-features.org/#PropertyShorthand). I had no idea what it was and how to fix it until I found [this solution](https://stackoverflow.com/a/50876566) so that's why I am fixing it here in this repo.

# Solution:
To change the [ecma option of UglifyJS](https://github.com/mishoo/UglifyJS2/tree/harmony#minify-options) from `8` to `5` to ensure maximum compatibility with older browsers.

I think it's not very safe to keep it at `8` because not all browsers are fully EcmaScript 8 and even 6 compatible yet.