### PR TITLE
Comments template fix

### DIFF
--- a/app/filters.php
+++ b/app/filters.php
@@ -63,7 +63,7 @@ add_filter('template_include', function ($template) {
 }, PHP_INT_MAX);
 
 /**
- * Tell WordPress how to find the compiled path of comments.blade.php
+ * Render comments.blade.php
  */
 add_filter('comments_template', function ($comments_template) {
     $comments_template = str_replace(
@@ -71,8 +71,16 @@ add_filter('comments_template', function ($comments_template) {
         '',
         $comments_template
     );
-    return template_path(locate_template(["views/{$comments_template}", $comments_template]) ?: $comments_template);
-}, 100);
+
+    $theme_template = locate_template(["views/{$comments_template}", $comments_template]);
+
+    if ($theme_template) {
+        echo template($theme_template);
+        return get_stylesheet_directory().'/index.php';
+    }
+
+    return $comments_template;
+}, PHP_INT_MAX);
 
 /**
  * Render WordPress searchform using Blade


### PR DESCRIPTION
## Submit a feature request or bug report

- [x] I've read the [guidelines for Contributing to Roots Projects](https://github.com/roots/guidelines/blob/master/CONTRIBUTING.md)
- [ ] This is a feature request
- [x] This is a bug report
- [x] This request isn't a duplicate of an [existing issue](https://github.com/roots/sage/issues)
- [x] I've read the [docs](https://roots.io/sage/docs) and [NPM Debugging Guidelines post](https://discourse.roots.io/t/npm-debugging-guidelines-failed-npm-install-bower-install-or-gulp-build-read-this/3060) and followed them (if applicable)
- [x] This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/c/sage) forums

<!-- Replace any `X` with your information. -->

---

**What is the current behaviour?**

Compiled comments template is included directly and that causes the error with missing $__env variable and that causes that e.g. @foreach cycle doesn't work.


**What is the expected or desired behavior?**

Comments template is rendered with Blade's render method.

---

## Bug report

<!-- (delete this section if not applicable) -->

**Please provide steps to reproduce, including full log output:**

1) add the following code to `partials/comments.blade.php`

```php
@foreach([1,2,3,4,5] as $i)
  {{ $i }}
@endforeach
```
2) an error occures

**Please describe your local environment:**

WordPress version: 4.9

**Where did the bug happen? Development or remote servers?**

Everywhere

**Is there a related [Discourse](https://discourse.roots.io/) thread or were any utilized (please link them)?**

https://discourse.roots.io/t/why-cant-i-foreach-my-var/12021/3

