### PR TITLE
Bump sage-installer

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "1387af18b4df853db96edd5d561c8545",
@@ -1280,16 +1280,16 @@
         },
         {
             "name": "roots/sage-installer",
-            "version": "1.3.6",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/roots/sage-installer.git",
-                "reference": "e811ab937a36b321ea88ec6000ab3d5019b8f2b1"
+                "reference": "f511e9ad8b7b10d3d809f3b645b4d44a9612874a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/roots/sage-installer/zipball/e811ab937a36b321ea88ec6000ab3d5019b8f2b1",
-                "reference": "e811ab937a36b321ea88ec6000ab3d5019b8f2b1",
+                "url": "https://api.github.com/repos/roots/sage-installer/zipball/f511e9ad8b7b10d3d809f3b645b4d44a9612874a",
+                "reference": "f511e9ad8b7b10d3d809f3b645b4d44a9612874a",
                 "shasum": ""
             },
             "require": {
@@ -1331,10 +1331,11 @@
                 "foundation",
                 "sage",
                 "tachyons",
+                "tailwindcss",
                 "theme",
                 "wordpress"
             ],
-            "time": "2018-04-25T17:45:56+00:00"
+            "time": "2018-08-17T00:33:43+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",


### PR DESCRIPTION
Updates `roots/sage-installer` to 1.4.1.

Includes a new Tailwind CSS preset and fixes a bug where certain paths needed to be escaped for the `postCreateProject` scripts to run.