### PR TITLE
Unescape get_language_attributes()

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!doctype html>
-<html {{ get_language_attributes() }}>
+<html {!! get_language_attributes() !!}>
   @include('partials.head')
   <body @php body_class() @endphp>
     @php do_action('get_header') @endphp


### PR DESCRIPTION
`get_language_attributes()` shouldn't be escaped in `app.blade.php` as brought up here https://github.com/roots/sage/pull/2089#commitcomment-30412267