### PR TITLE
Pass controller data to comments and search form partials

### DIFF
--- a/app/filters.php
+++ b/app/filters.php
@@ -52,12 +52,9 @@ collect([
  * Render page using Blade
  */
 add_filter('template_include', function ($template) {
-    $data = collect(get_body_class())->reduce(function ($data, $class) use ($template) {
-        return apply_filters("sage/template/{$class}/data", $data, $template);
-    }, []);
     if ($template) {
-        echo template($template, $data);
-        return get_stylesheet_directory().'/index.php';
+        echo template($template, collect_template_data($template));
+        return get_stylesheet_directory() . '/index.php';
     }
     return $template;
 }, PHP_INT_MAX);
@@ -75,8 +72,8 @@ add_filter('comments_template', function ($comments_template) {
     $theme_template = locate_template(["views/{$comments_template}", $comments_template]);
 
     if ($theme_template) {
-        echo template($theme_template);
-        return get_stylesheet_directory().'/index.php';
+        echo template($theme_template, collect_template_data($comments_template));
+        return get_stylesheet_directory() . '/index.php';
     }
 
     return $comments_template;
@@ -86,7 +83,7 @@ add_filter('comments_template', function ($comments_template) {
  * Render WordPress searchform using Blade
  */
 add_filter('get_search_form', function () {
-    return template('partials.searchform');
+    return template('partials.searchform', collect_template_data('/partials/searchform.blade.php'));
 });
 
 /**

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -140,3 +140,14 @@ function display_sidebar()
     isset($display) || $display = apply_filters('sage/display_sidebar', false);
     return $display;
 }
+
+/**
+ * @param string $template Path to the template file
+ * @return array Data to be provided to template
+ */
+function collect_template_data($template = '')
+{
+    return collect(get_body_class())->reduce(function ($data, $class) use ($template) {
+        return apply_filters("sage/template/{$class}/data", $data, $template);
+    }, []);
+}


### PR DESCRIPTION
Refactor the code for collecting template data to `helpers.php` and invoke it in `filters.php` to get data when both templates and the comments and search form partials are rendered.

Closes #2105.

Also handles #2100 (thanks @mejta!).

Lastly, as @mejta pointed out, would enable @MWDelaney's previous PR #2091 to work correctly.