### PR TITLE
Better Gutenberg support

### DIFF
--- a/app/setup.php
+++ b/app/setup.php
@@ -66,6 +66,13 @@ add_action('after_setup_theme', function () {
     add_theme_support('customize-selective-refresh-widgets');
 
     /**
+     * Gutenberg support
+     * @link https://wordpress.org/gutenberg/handbook/extensibility/theme-support/
+     */
+    add_theme_support('editor-styles');
+    add_theme_support('align-wide');
+
+    /**
      * Use main stylesheet for visual editor
      * @see resources/assets/styles/layouts/_tinymce.scss
      */

--- a/resources/assets/styles/components/_wp-classes.scss
+++ b/resources/assets/styles/components/_wp-classes.scss
@@ -1,6 +1,6 @@
 /**
  * WordPress Generated Classes
- * @see http://codex.wordpress.org/CSS#WordPress_Generated_Classes
+ * @link http://codex.wordpress.org/CSS#WordPress_Generated_Classes
  */
 
 /** Media alignment */
@@ -9,6 +9,26 @@
   margin-right: 0;
   max-width: 100%;
   height: auto;
+}
+
+.alignwide {
+  margin-left: -($grid-gutter-width / 2);
+  margin-right: -($grid-gutter-width / 2);
+  max-width: none;
+
+  @include media-breakpoint-up(sm) {
+    margin-left: -$grid-gutter-width;
+    margin-right: -$grid-gutter-width;
+  }
+}
+
+.alignfull {
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
 }
 
 .aligncenter {
@@ -36,16 +56,16 @@
 }
 
 /** Captions */
-.wp-caption {
+.wp-block-image {
   @extend .figure;
 }
 
-.wp-caption img {
+.wp-block-image img {
   @extend .figure-img;
   @extend .img-fluid;
 }
 
-.wp-caption-text {
+.wp-block-image figcaption {
   @extend .figure-caption;
 }
 
@@ -53,4 +73,10 @@
 .screen-reader-text {
   @extend .sr-only;
   @extend .sr-only-focusable;
+}
+
+/** Gutenberg image blocks */
+.alignwide.wp-block-image img,
+.alignfull.wp-block-image img {
+  width: 100vw;
 }


### PR DESCRIPTION
see https://wordpress.org/gutenberg/handbook/extensibility/theme-support/

todo:

* [ ] add `add_theme_support('editor-color-palette')` based on colors from theme (auto-save the theme CSS variables to JSON ([ref](https://itnext.io/sharing-variables-between-js-and-sass-using-webpack-sass-loader-713f51fa7fa0)))
* [ ] add theme styles to block editor