### PR TITLE
Remove rendered Blades on theme install/uninstall

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -140,3 +140,36 @@ function display_sidebar()
     isset($display) || $display = apply_filters('sage/display_sidebar', false);
     return $display;
 }
+
+/**
+ * Returns an array of SPLFileInfo objects representing all rendered Blades.
+ *
+ * @return array
+ */
+function get_rendered_blades()
+{
+    return collect(
+        \iterator_to_array(
+            new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator(
+                    realpath(config('view.compiled')),
+                    \FilesystemIterator::SKIP_DOTS))))
+        ->filter(function($file) {
+            /** This is an approximation of what a Blade filename should look like. */
+            return preg_match('/([a-z0-9]{40})(\.php)/m', $file->getFilename()) === 1;
+        })
+        ->all();
+}
+
+/**
+ * Removes all rendered Blades from the cache.
+ *
+ * @return void
+ */
+function remove_rendered_blades()
+{
+    collect(get_rendered_blades())
+        ->map(function($file) {
+            unlink($file->getRealPath());
+        });
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -153,8 +153,12 @@ function get_rendered_blades()
             new \RecursiveIteratorIterator(
                 new \RecursiveDirectoryIterator(
                     realpath(config('view.compiled')),
-                    \FilesystemIterator::SKIP_DOTS))))
-        ->filter(function($file) {
+                    \FilesystemIterator::SKIP_DOTS
+                )
+            )
+        )
+    )
+        ->filter(function ($file) {
             /** This is an approximation of what a Blade filename should look like. */
             return preg_match('/([a-z0-9]{40})(\.php)/m', $file->getFilename()) === 1;
         })
@@ -169,7 +173,7 @@ function get_rendered_blades()
 function remove_rendered_blades()
 {
     collect(get_rendered_blades())
-        ->map(function($file) {
+        ->map(function ($file) {
             unlink($file->getRealPath());
         });
 }

--- a/app/setup.php
+++ b/app/setup.php
@@ -130,3 +130,13 @@ add_action('after_setup_theme', function () {
         return "<?= " . __NAMESPACE__ . "\\asset_path({$asset}); ?>";
     });
 });
+
+/**
+ * Remove any old blades when we activate this theme.
+ */
+add_action('after_switch_theme', __NAMESPACE__.'\\remove_rendered_blades');
+
+/**
+ * Be nice and remove our blades when the theme is removed.
+ */
+add_action('switch_theme', __NAMESPACE__.'\\remove_rendered_blades');


### PR DESCRIPTION
This PR would address some of the concerns in #1987. It doesn't add a command-line function for manipulating Blades, but it does make Sage a slightly kinder WordPress citizen by cleaning up Blades when installed/uninstalled, and provides some helper methods for doing that at other times. It endeavors to be relatively careful, and only delete the files it needs to delete, leaving other files alone.

The reason it doesn't examine existing Blade templates to find their rendered versions and delete _those_ is because part of the ostensible purpose is to clean up unnecessary Blades when changing themes: If the original Blade templates have been changed or removed during development, the "orphaned" rendered files would not be found.

I considered adding the a "build all Blades on install" feature, but felt that was a little too presumptuous and could theoretically lead to significantly increased load when activating a theme if there are a lot of Blades to render. I'd be happy to modify the PR to add that feature, though.