### PR TITLE
Hook run sequence fix

### DIFF
--- a/app/filters.php
+++ b/app/filters.php
@@ -47,6 +47,15 @@ collect([
  * Render page using Blade
  */
 add_filter('template_include', function ($template) {
+    collect(['get_header', 'wp_head'])->each(function ($tag) {
+        ob_start();
+        do_action($tag);
+        $c = ob_get_clean();
+        remove_all_actions($tag);
+        add_action($tag, function () use ($c) {
+            echo $c;
+        });
+    });
     $data = collect(get_body_class())->reduce(function ($data, $class) use ($template) {
         return apply_filters("sage/template/{$class}/data", $data, $template);
     }, []);

--- a/app/filters.php
+++ b/app/filters.php
@@ -50,10 +50,10 @@ add_filter('template_include', function ($template) {
     collect(['get_header', 'wp_head'])->each(function ($tag) {
         ob_start();
         do_action($tag);
-        $c = ob_get_clean();
+        $output = ob_get_clean();
         remove_all_actions($tag);
-        add_action($tag, function () use ($c) {
-            echo $c;
+        add_action($tag, function () use ($output) {
+            echo $output;
         });
     });
     $data = collect(get_body_class())->reduce(function ($data, $class) use ($template) {

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -52,10 +52,6 @@ function config($key = null, $default = null)
  */
 function template($file, $data = [])
 {
-    if (!is_admin() && remove_action('wp_head', 'wp_enqueue_scripts', 1)) {
-        wp_enqueue_scripts();
-    }
-
     return sage('blade')->render($file, $data);
 }
 


### PR DESCRIPTION
This brings hook run sequence in line with expected WordPress theme behavior, and solves compatibility issues with plugins that relies on this expected behavior. It also moves the initial execution of get_header, wp_head and their child hooks to before the data filters. The logic in controllers will happen closer to where that logic it is expected to happen in relation to the hook system.

This solves the issue described in #2116.