### PR TITLE
Do not ignore vendors for plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ dist
 node_modules
 npm-debug.log
 yarn-error.log
-vendor
+/vendor
 resources/assets/config-local.json


### PR DESCRIPTION
Hi, team. Thanks for great project! I appreciate it very much!

Here is my tiny suggestion, I am very happy if you can consider it.

# Suggestion

If there is a plugin containing a vendor directory([like this](https://wordpress.org/plugins/wp-nested-pages/)), it will be ignored, so why not just ignore the vendor directory in the root?