### PR TITLE
Unescape post titles

### DIFF
--- a/resources/views/partials/content-search.blade.php
+++ b/resources/views/partials/content-search.blade.php
@@ -1,6 +1,6 @@
 <article @php post_class() @endphp>
   <header>
-    <h2 class="entry-title"><a href="{{ get_permalink() }}">{{ get_the_title() }}</a></h2>
+    <h2 class="entry-title"><a href="{{ get_permalink() }}">{!! get_the_title() !!}</a></h2>
     @if (get_post_type() === 'post')
       @include('partials/entry-meta')
     @endif

--- a/resources/views/partials/content-single.blade.php
+++ b/resources/views/partials/content-single.blade.php
@@ -1,6 +1,6 @@
 <article @php post_class() @endphp>
   <header>
-    <h1 class="entry-title">{{ get_the_title() }}</h1>
+    <h1 class="entry-title">{!! get_the_title() !!}</h1>
     @include('partials/entry-meta')
   </header>
   <div class="entry-content">

--- a/resources/views/partials/content.blade.php
+++ b/resources/views/partials/content.blade.php
@@ -1,6 +1,6 @@
 <article @php post_class() @endphp>
   <header>
-    <h2 class="entry-title"><a href="{{ get_permalink() }}">{{ get_the_title() }}</a></h2>
+    <h2 class="entry-title"><a href="{{ get_permalink() }}">{!! get_the_title() !!}</a></h2>
     @include('partials/entry-meta')
   </header>
   <div class="entry-summary">


### PR DESCRIPTION
Don't escape post titles. Fixes problems with special characters like quotes.

Consistent with: https://github.com/roots/sage/blob/master/resources/views/partials/page-header.blade.php