### PR TITLE
Decrease optipng level

### DIFF
--- a/resources/assets/build/webpack.config.optimize.js
+++ b/resources/assets/build/webpack.config.optimize.js
@@ -9,7 +9,7 @@ const config = require('./config');
 module.exports = {
   plugins: [
     new ImageminPlugin({
-      optipng: { optimizationLevel: 7 },
+      optipng: { optimizationLevel: 2 },
       gifsicle: { optimizationLevel: 3 },
       pngquant: { quality: '65-90', speed: 4 },
       svgo: {


### PR DESCRIPTION
After seeing the following graph [here](http://sweetme.at/2013/09/11/how-to-maximize-png-image-compression-with-optipng/) we decided to test optimsation level 2 for OptiPNG instead of 7. This is because, acording to the graph we would notice no real difference in avarage file size but would notice a speed increase with our builds.

![image](https://user-images.githubusercontent.com/9092863/50760280-39a7c480-125f-11e9-9bd6-d28171289abe.png)

After testing , we noticed our theme build go from a build time of over 10 mins (just on the 94% asset optimisation step) to an avarage of `150.75s`. All the while, we only gained 10-15kb per png file which we believe more than reasonable for a build speed increase of this magnatude.