### PR TITLE
Filter template hierarchy for embed templates

### DIFF
--- a/app/filters.php
+++ b/app/filters.php
@@ -38,7 +38,7 @@ add_filter('excerpt_more', function () {
  */
 collect([
     'index', '404', 'archive', 'author', 'category', 'tag', 'taxonomy', 'date', 'home',
-    'frontpage', 'page', 'paged', 'search', 'single', 'singular', 'attachment'
+    'frontpage', 'page', 'paged', 'search', 'single', 'singular', 'attachment', 'embed'
 ])->map(function ($type) {
     add_filter("{$type}_template_hierarchy", __NAMESPACE__.'\\filter_templates');
 });


### PR DESCRIPTION
Add `embed` to the template hierarchy filters in Sage, so that the embed template can be overridden from the `views` folder.

Closes #2142 

Once this is merged, you can copy `wp-includes/theme-compat/embed.php` to `views` and adapt it however you want, just like any template file in Sage. Better yet, create `views/embed.blade.php` , with something like:

```blade
@include('partials.header-embed')

@if (have_posts())
  @while (have_posts()) @php the_post() @endphp
    @include('partials.embed-content')
  @endwhile
@else
  @include('partials.embed-404')
@endif

@include('partials.footer-embed')
```

The above assumes that you've also added `embed-content`, `embed-404`, and `footer-embed` templates to the `partials` folder, but you don't have to if you don't need to customize them. 