### PR TITLE
Debug helper

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -136,3 +136,39 @@ function display_sidebar()
     isset($display) || $display = apply_filters('sage/display_sidebar', false);
     return $display;
 }
+
+/**
+ * Debug to debug.log in public dir or the file specified in wp-config SAGE_DEBUG_LOG_PATH
+ * @param  mixed $data String, array or any object supported by var_export
+ * @return bool  true if successful
+ */
+function debug($data) {
+
+  // Only works on debug
+  if (!WP_DEBUG) {
+    return false;
+  }
+
+  // debug.log file
+  $log_path = join(DIRECTORY_SEPARATOR, [ABSPATH, 'debug.log']);
+
+  // unless specified in wp-config
+  if (SAGE_DEBUG_LOG_PATH) {
+    $log_path = SAGE_DEBUG_LOG_PATH;
+  }
+
+  // create line
+  $string = "";
+  if (is_string($data)) {
+    $string = $data;
+  } else {
+    $string = var_export($data, true);
+  }
+
+  // add end of line
+  $line = $string . PHP_EOL;
+
+  // append to file
+  file_put_contents($log_path, $line, FILE_APPEND);
+  return true;
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -153,7 +153,7 @@ function debug($data) {
   $log_path = join(DIRECTORY_SEPARATOR, [ABSPATH, 'debug.log']);
 
   // unless specified in wp-config
-  if (SAGE_DEBUG_LOG_PATH) {
+  if (defined(SAGE_DEBUG_LOG_PATH)) {
     $log_path = SAGE_DEBUG_LOG_PATH;
   }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -153,7 +153,7 @@ function debug($data) {
   $log_path = join(DIRECTORY_SEPARATOR, [ABSPATH, 'debug.log']);
 
   // unless specified in wp-config
-  if (defined(SAGE_DEBUG_LOG_PATH)) {
+  if (defined('SAGE_DEBUG_LOG_PATH')) {
     $log_path = SAGE_DEBUG_LOG_PATH;
   }
 


### PR DESCRIPTION
Debug Helper
---

Log variables to debug.log with: 

`\App\debug($mixed)`

Works with strings, arrays or any filetype supported by var_export
[https://secure.php.net/manual/en/function.var-export.php](https://secure.php.net/manual/en/function.var-export.php)

(Why var_export instead of var_dump? outputs valid php code, more readable)

Debug log is simply `debug.log` in your public path, but can be overwritten in wp-config: 

```
define('SAGE_DEBUG_LOG_PATH', '/yourpath/www/web1/public/wp-content/themes/sage/debugging.log');
```

In case you forget to remove it, works only when WP_DEBUG is true

Example
---

`\App\debug($myvar)`

```php
array (
  'academic' => 
  array (
    'academic' => 'Academic',
  ),
  'integrated' => 
  array (
    'integrated' => 'Integrated',
  ),
  'on-aircraft' => 
  array (
    'on-aircraft' => 'On-Aircraft',
  ),
  'simulator' => 
  array (
    'simulator' => 'Simulator',
  ),
)
```