### PR TITLE
⚠️ Blade templates directly accessible

### DIFF
--- a/resources/views/.htaccess
+++ b/resources/views/.htaccess
@@ -1,0 +1,12 @@
+<FilesMatch ".+\.(blade\.php)$">
+    <IfModule mod_authz_core.c>
+        # Apache 2.4
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        # Apache 2.2
+        Order deny,allow
+        Deny from all
+    </IfModule>
+</FilesMatch>
+


### PR DESCRIPTION
⚠️ [yesterday it was brought up](https://discourse.roots.io/t/blade-templates-directly-accessible-via-web-browser-on-server/15059) that you can view blade templates in plain-text when accessing the files directly from your browser

![image](https://user-images.githubusercontent.com/115911/54378007-fc3f2900-464b-11e9-938c-231155c90ec1.png)

this is not ideal. sage isn't the only theme affected by this — any wordpress theme that uses blade or twig (all timber themes) have the same problem because the views are publicly accessible:

![image](https://user-images.githubusercontent.com/115911/54378258-8c7d6e00-464c-11e9-847b-54c0cfb9265a.png)

while this PR only will only benefit apache users, the install docs will also be updated (see below) with instructions for nginx users. trellis is being updated to include preventing access to blade and twig files out of the box.

ref https://github.com/roots/trellis/pull/1075
ref https://github.com/roots/docs/pull/180

if you use a managed wordpress host, you'll need to reach out to their support team to ask them if they can make a similar change to their server config. i've asked kinsta if they'd be able to make this change globally and waiting to hear back.