### PR TITLE
Continued Sage 10 cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
-# Include your project-specific ignores in this file
-# Read about how to use .gitignore: https://help.github.com/articles/ignoring-files
-.cache-loader
-dist
-node_modules
+/node_modules
+/vendor
+/dist
 npm-debug.log
 yarn-error.log
-vendor
-resources/assets/config-local.json

--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ Sage is a WordPress starter theme with a modern development workflow.
 
 * Sass for stylesheets
 * Modern JavaScript
-* [Webpack](https://webpack.github.io/) for compiling assets, optimizing images, and concatenating and minifying files
+* [Laravel Mix](https://github.com/JeffreyWay/laravel-mix) for compiling assets and concatenating and minifying files
 * [Browsersync](http://www.browsersync.io/) for synchronized browser testing
-* [Blade](https://laravel.com/docs/5.6/blade) as a templating engine
-* [Controller](https://github.com/soberwp/controller) for passing data to Blade templates
+* [Blade](https://laravel.com/docs/5.8/blade) as a templating engine
 * CSS framework (optional): [Bootstrap 4](https://getbootstrap.com/), [Bulma](https://bulma.io/), [Foundation](https://foundation.zurb.com/), [Tachyons](http://tachyons.io/), [Tailwind](https://tailwindcss.com/)
 
 See a working example at [roots-example-project.com](https://roots-example-project.com/).
@@ -31,7 +30,7 @@ Make sure all dependencies have been installed before moving on:
 
 Install Sage using Composer from your WordPress themes directory (replace `your-theme-name` below with the name of your theme):
 
-```shell
+```sh
 # @ app/themes/ or wp-content/themes/
 $ composer create-project roots/sage your-theme-name
 ```
@@ -46,7 +45,7 @@ During theme installation you will have options to update `style.css` theme head
 
 ## Theme structure
 
-```shell
+```sh
 themes/your-theme-name/   # → Root of your Sage based theme
 ├── app/                  # → Theme PHP
 │   ├── Composers/        # → Composer files
@@ -79,6 +78,7 @@ themes/your-theme-name/   # → Root of your Sage based theme
 │   └── views/            # → Theme templates
 │       ├── layouts/      # → Base templates
 │       └── partials/     # → Partial templates
+├── storage/              # → Storage location for cache (never edit)
 └── vendor/               # → Composer packages (never edit)
 ```
 
@@ -89,9 +89,7 @@ Edit `app/setup.php` to enable or disable theme features, setup navigation menus
 ## Theme development
 
 * Run `yarn` from the theme directory to install dependencies
-* Update `resources/assets/config.json` settings:
-  * `devUrl` should reflect your local development hostname
-  * `publicPath` should reflect your WordPress folder structure (`/wp-content/themes/sage` for non-[Bedrock](https://roots.io/bedrock/) installs)
+* Update `webpack.mix.js` with your local dev URL
 
 ### Build commands
 

--- a/app/Providers/ThemeServiceProvider.php
+++ b/app/Providers/ThemeServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class ThemeServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
+}

--- a/app/setup.php
+++ b/app/setup.php
@@ -22,7 +22,7 @@ add_action('wp_enqueue_scripts', function () {
     $styles = ['styles/app.css'];
 
     foreach ($styles as $stylesheet) {
-        if ($asset = asset($stylesheet)->exists()) {
+        if (asset($stylesheet)->exists()) {
             wp_enqueue_style('sage/'.basename($stylesheet, '.css'), asset($stylesheet)->uri(), false, null);
         }
     }

--- a/app/setup.php
+++ b/app/setup.php
@@ -2,7 +2,6 @@
 
 namespace App;
 
-use function Roots\add_actions;
 use function Roots\asset;
 use function Roots\config;
 use function Roots\view;
@@ -102,15 +101,4 @@ add_action('widgets_init', function () {
         'name' => __('Footer', 'sage'),
         'id' => 'sidebar-footer'
     ] + $config);
-});
-
-/**
- * Remove Blade cache when theme is activated, changed, or removed.
- */
-add_actions(['after_switch_theme', 'switch_theme'], function () {
-    return collect(glob(config('view.compiled') . '/*.php'))
-        ->filter()
-        ->map(function ($file) {
-            unlink($file);
-        });
 });

--- a/config/app.php
+++ b/config/app.php
@@ -6,6 +6,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Name
+    |--------------------------------------------------------------------------
+    |
+    | This value is the name of your application. This value is used when the
+    | framework needs to place the application's name in a notification or
+    | any other location as required by the application or its packages.
+    |
+    */
+
+    'name' => env('APP_NAME', wp_get_theme()->get('Name')),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Environment
     |--------------------------------------------------------------------------
     |
@@ -55,6 +68,7 @@ return [
     */
 
     'providers' => [
+        App\Providers\ThemeServiceProvider::class,
         // App\SomeService\SomeServiceServiceProvider::class,
     ],
 

--- a/config/view.php
+++ b/config/view.php
@@ -14,7 +14,7 @@ return [
 
     'paths' => [
         get_theme_file_path('/resources/views'),
-        get_parent_theme_file_path('/resources/views')
+        get_parent_theme_file_path('/resources/views'),
     ],
 
     /*
@@ -28,7 +28,7 @@ return [
     |
     */
 
-    'compiled' => wp_upload_dir()['basedir'] . '/acorn/cache',
+    'compiled' => get_theme_file_path('/storage/framework/views'),
 
     /*
     |--------------------------------------------------------------------------
@@ -90,6 +90,6 @@ return [
     */
 
     'directives' => [
-        'asset'  => Roots\Acorn\Assets\AssetDirective::class
+        'asset'  => Roots\Acorn\Assets\AssetDirective::class,
     ],
 ];

--- a/resources/assets/scripts/app.js
+++ b/resources/assets/scripts/app.js
@@ -1,22 +1,28 @@
-// External dependencies
+/**
+ * External Dependencies
+ */
 import 'jquery';
 import 'bootstrap';
 
-// Local dependencies
+/**
+ * Local Dependencies
+ */
 import Router from './util/Router';
 import common from './routes/common';
-import home from './routes/home';
 import aboutUs from './routes/about';
 
-// Populate Router instance with DOM routes
+/**
+ * Populate the Router instance with DOM routes.
+ *
+ * common – Fired on all pages.
+ * aboutUs – Fired on the About Us page, note the change from about-us to aboutUs (camelCase).
+ */
 const routes = new Router({
-  // All pages
   common,
-  // Home page
-  home,
-  // About Us page, note the change from about-us to aboutUs.
   aboutUs,
 });
 
-// Load Events
+/**
+ * Load Events
+ */
 jQuery(document).ready(() => routes.loadEvents());

--- a/resources/assets/scripts/customizer.js
+++ b/resources/assets/scripts/customizer.js
@@ -1,3 +1,15 @@
+/**
+ * This file allows you to add functionality to the Theme Customizer
+ * live preview. jQuery is readily available.
+ *
+ * {@link https://codex.wordpress.org/Theme_Customization_API}
+ */
+
+/**
+ * Change the blog name value.
+ *
+ * @param {string} value
+ */
 wp.customize('blogname', (value) => {
   value.bind(to => $('.brand').text(to));
 });

--- a/resources/assets/scripts/routes/about.js
+++ b/resources/assets/scripts/routes/about.js
@@ -1,8 +1,14 @@
+/**
+ * About Us
+ *
+ * init – Fired on About Us page.
+ * finalized – Fired on About Us page, after page specific JS is fired.
+ */
 export default {
   init() {
-    // JavaScript to be fired on the about us page
+    //
   },
   finalize() {
-    // JavaScript to be fired on the about page, after the init JS
+    //
   },
 };

--- a/resources/assets/scripts/routes/common.js
+++ b/resources/assets/scripts/routes/common.js
@@ -1,8 +1,14 @@
+/**
+ * Common
+ *
+ * init – Fired on all pages.
+ * finialized – Fired on all pages, after page specific JS is fired.
+ */
 export default {
   init() {
-    // JavaScript to be fired on all pages
+    //
   },
   finalize() {
-    // JavaScript to be fired on all pages, after page specific JS is fired
+    //
   },
 };

--- a/resources/assets/scripts/routes/home.js
+++ b/resources/assets/scripts/routes/home.js
@@ -1,8 +1,0 @@
-export default {
-  init() {
-    // JavaScript to be fired on the home page
-  },
-  finalize() {
-    // JavaScript to be fired on the home page, after the init JS
-  },
-};

--- a/resources/assets/scripts/util/Router.js
+++ b/resources/assets/scripts/util/Router.js
@@ -12,6 +12,7 @@ class Router {
 
   /**
    * Create a new Router
+   *
    * @param {Object} routes
    */
   constructor(routes) {
@@ -20,6 +21,7 @@ class Router {
 
   /**
    * Fire Router events
+   *
    * @param {string} route DOM-based route derived from body classes (`<body class="...">`)
    * @param {string} [event] Events on the route. By default, `init` and `finalize` events are called.
    * @param {string} [arg] Any custom argument to be passed to the event.

--- a/resources/assets/scripts/util/camelCase.js
+++ b/resources/assets/scripts/util/camelCase.js
@@ -1,5 +1,6 @@
 /**
- * the most terrible camelizer on the internet, guaranteed!
+ * A simple camelCase converter.
+ *
  * @param {string} str String that isn't camel-case, e.g., CAMeL_CaSEiS-harD
  * @return {string} String converted to camel-case, e.g., camelCaseIsHard
  */

--- a/resources/functions.php
+++ b/resources/functions.php
@@ -6,6 +6,7 @@
 
 /**
  * Helper function for prettying up errors
+ *
  * @param string $message
  * @param string $subtitle
  * @param string $title

--- a/storage/framework/cache/.gitignore
+++ b/storage/framework/cache/.gitignore
@@ -1,0 +1,3 @@
+*
+!data/
+!.gitignore

--- a/storage/framework/cache/data/.gitignore
+++ b/storage/framework/cache/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/storage/framework/views/.gitignore
+++ b/storage/framework/views/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -11,7 +11,7 @@ const mix = require('laravel-mix');
  |
  */
 
-// Settings
+// Public Path
 mix.setPublicPath('./dist');
 
 // Browsersync
@@ -29,7 +29,7 @@ mix.browserSync({
 // Styles
 mix.sass('resources/assets/styles/app.scss', 'styles');
 
-// Javascript
+// JavaScript
 mix.js('resources/assets/scripts/app.js', 'scripts')
    .js('resources/assets/scripts/customizer.js', 'scripts')
    .extract();

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -31,9 +31,8 @@ mix.sass('resources/assets/styles/app.scss', 'styles');
 
 // Javascript
 mix.js('resources/assets/scripts/app.js', 'scripts')
+   .js('resources/assets/scripts/customizer.js', 'scripts')
    .extract();
-
-mix.js('resources/assets/scripts/customizer.js', 'scripts');
 
 // Assets
 mix.copyDirectory('resources/assets/images', 'dist/images')


### PR DESCRIPTION
## Changelog

### Enhancements

- Add `name` configuration to `config/app.php` (defaults to theme name).
- Move default cache location to `storage/`.
- Add a ServiceProvider stub.
- Add missing trailing commas to configs.
- Remove/revert automatic Blade cache removal action as it is no longer necessary.
- Clean up `.gitignore`.
- Clean up JavaScript docblocks.
- Remove `home.js` example leaving `about.js` to give an example of camelCase.
- Remove leftover Sage 9 information from the readme.

### Todo

- Move the DOM-based router to it's own package.
- Change Acorn's manifest/asset class to handle leading slashes.
- Figure out a solution to handle `images` and `fonts` versioning (attempt a PR into Laravel Mix?)
- Decide on a solution for changing cache busting from args to filenames ([laravel-mix-versionhash](https://github.com/ctf0/laravel-mix-versionhash) or attempt a PR into Laravel Mix).
- Update documentation for Sage 10.
- Write a changelog.
- Bump #2167 for when 5.2 releases.
- Sage CLI (probably after release?)