### PR TITLE
[Sage 10] Add clean:views npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "mix:hot": "webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
     "clean": "run-p clean:*",
     "clean:dist": "rimraf dist",
+    "clean:views": "rimraf storage/framwork/views/*.php",
     "lint": "run-s -c lint:*",
     "lint:scripts": "eslint resources/assets/scripts",
     "lint:styles": "stylelint \"resources/assets/**/*.{vue,css,sass,scss,sss,less}\"",


### PR DESCRIPTION
Since views are in a predictable location within the theme, this might be handy. A side effect of adding this is that generated views are now cleared on every production build, which might be a good thing. If not, it’s not hard to change.