### PR TITLE
[Sage 10] Add src and public mix path helpers

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,5 +1,11 @@
 const mix = require('laravel-mix');
 
+// Public path helper
+const public = path => `${mix.config.publicPath}/${path}`;
+
+// Source path helper
+const src = path => `resources/assets/${path}`;
+
 /*
  |--------------------------------------------------------------------------
  | Mix Asset Management
@@ -27,16 +33,16 @@ mix.browserSync({
 });
 
 // Styles
-mix.sass('resources/assets/styles/app.scss', 'styles');
+mix.sass(src('styles/app.scss'), 'styles');
 
 // JavaScript
-mix.js('resources/assets/scripts/app.js', 'scripts')
-   .js('resources/assets/scripts/customizer.js', 'scripts')
+mix.js(src('scripts/app.js'), 'scripts')
+   .js(src('scripts/customizer.js'), 'scripts')
    .extract();
 
 // Assets
-mix.copyDirectory('resources/assets/images', 'dist/images')
-   .copyDirectory('resources/assets/fonts', 'dist/fonts');
+mix.copyDirectory(src('images'), public('images'))
+   .copyDirectory(src('fonts'), public('fonts'));
 
 // Autoload
 mix.autoload({


### PR DESCRIPTION
Since Mix uses the `webpack.mix.js` path as the webpack context and doesn’t let us change the context, having a helper can make it easier to add new assets. It also provides a single source of truth for the assets source directory (one less thing to _mix_ up — pun intended).

Also, this adds a `public` function which just makes it easy for setting the `from` path in the `copyDirectory` task.

I figure by including the definitions of these functions within the `webpack.mix.js` file itself it makes it clear to Sage users that they are not a part of Mix.