### PR TITLE
[Sage 10] Minor syntax changes + publicPath helper name change

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,7 +1,7 @@
 const mix = require('laravel-mix');
 
 // Public path helper
-const public = path => `${mix.config.publicPath}/${path}`;
+const out = path => `${mix.config.publicPath}/${path}`;
 
 // Source path helper
 const src = path => `resources/assets/${path}`;
@@ -25,7 +25,7 @@ mix.browserSync({
   proxy: 'https://example.test',
   files: [
     '(app|config|resources)/**/*.php',
-    public`(styles|scripts)/**/*.(css|js)`,
+    out`(styles|scripts)/**/*.(css|js)`,
   ],
 });
 
@@ -38,8 +38,8 @@ mix.js(src`scripts/app.js`, 'scripts')
    .extract();
 
 // Assets
-mix.copyDirectory(src`images`, public`images`)
-   .copyDirectory(src`fonts`, public`fonts`);
+mix.copyDirectory(src`images`, out`images`)
+   .copyDirectory(src`fonts`, out`fonts`);
 
 // Autoload
 mix.autoload({

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,7 +1,7 @@
 const mix = require('laravel-mix');
 
 // Public path helper
-const out = path => `${mix.config.publicPath}/${path}`;
+const publicPath = path => `${mix.config.publicPath}/${path}`;
 
 // Source path helper
 const src = path => `resources/assets/${path}`;
@@ -25,7 +25,7 @@ mix.browserSync({
   proxy: 'https://example.test',
   files: [
     '(app|config|resources)/**/*.php',
-    out`(styles|scripts)/**/*.(css|js)`,
+    publicPath`(styles|scripts)/**/*.(css|js)`,
   ],
 });
 
@@ -38,8 +38,8 @@ mix.js(src`scripts/app.js`, 'scripts')
    .extract();
 
 // Assets
-mix.copyDirectory(src`images`, out`images`)
-   .copyDirectory(src`fonts`, out`fonts`);
+mix.copyDirectory(src`images`, publicPath`images`)
+   .copyDirectory(src`fonts`, publicPath`fonts`);
 
 // Autoload
 mix.autoload({

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -24,25 +24,22 @@ mix.setPublicPath('./dist');
 mix.browserSync({
   proxy: 'https://example.test',
   files: [
-    'app/**/*.php',
-    'config/**/*.php',
-    'resources/views/**/*.php',
-    'dist/styles/**/*.css',
-    'dist/scripts/**/*.js'
+    '(app|config|resources)/**/*.php',
+    public`(styles|scripts)/**/*.(css|js)`,
   ],
 });
 
 // Styles
-mix.sass(src('styles/app.scss'), 'styles');
+mix.sass(src`styles/app.scss`, 'styles');
 
 // JavaScript
-mix.js(src('scripts/app.js'), 'scripts')
-   .js(src('scripts/customizer.js'), 'scripts')
+mix.js(src`scripts/app.js`, 'scripts')
+   .js(src`scripts/customizer.js`, 'scripts')
    .extract();
 
 // Assets
-mix.copyDirectory(src('images'), public('images'))
-   .copyDirectory(src('fonts'), public('fonts'));
+mix.copyDirectory(src`images`, public`images`)
+   .copyDirectory(src`fonts`, public`fonts`);
 
 // Autoload
 mix.autoload({


### PR DESCRIPTION
* Combine watch rules using extended glob patterns (tested + works).
* Use template literals for the mix helpers. Makes it seem less cluttered since we lose a bunch of parentheses.
* `public` is a future reserved word in JS so I switched it to `out` (other suggestions welcome).