### PR TITLE
[Sage 10] Replace jQuery’s .ready()

### DIFF
--- a/resources/assets/scripts/app.js
+++ b/resources/assets/scripts/app.js
@@ -10,14 +10,7 @@ import 'bootstrap';
 import Router from './util/Router';
 import common from './routes/common';
 import aboutUs from './routes/about';
-
-/**
- * Helper function for document readiness
- */
-function ready(fn) {
-  if (document.readyState !== 'loading') return fn();
-  document.addEventListener('DOMContentLoaded', fn);
-}
+import { ready } from './utils';
 
 /**
  * Populate the Router instance with DOM routes.

--- a/resources/assets/scripts/app.js
+++ b/resources/assets/scripts/app.js
@@ -25,4 +25,4 @@ const routes = new Router({
 /**
  * Load Events
  */
-jQuery(document).ready(() => routes.loadEvents());
+document.addEventListener('DOMContentLoaded', () => routes.loadEvents());

--- a/resources/assets/scripts/app.js
+++ b/resources/assets/scripts/app.js
@@ -12,6 +12,14 @@ import common from './routes/common';
 import aboutUs from './routes/about';
 
 /**
+ * Helper function for document readiness
+ */
+function ready(fn) {
+  if (document.readyState !== 'loading') return fn();
+  document.addEventListener('DOMContentLoaded', fn);
+}
+
+/**
  * Populate the Router instance with DOM routes.
  *
  * common – Fired on all pages.
@@ -25,4 +33,4 @@ const routes = new Router({
 /**
  * Load Events
  */
-document.addEventListener('DOMContentLoaded', () => routes.loadEvents());
+ready(() => routes.loadEvents());

--- a/resources/assets/scripts/utils.js
+++ b/resources/assets/scripts/utils.js
@@ -1,0 +1,8 @@
+/**
+ * Execute a function when the DOM is fully loaded.
+ *
+ * @param {function} fn
+ */
+export const ready = fn => document.readyState !== 'loading'
+  ? window.setTimeout(fn, 0)
+  : document.addEventListener('DOMContentLoaded', fn);


### PR DESCRIPTION
Replacements of jQuery’s `$(document).ready()` function usually look something like this:
```js
function ready(callback) {
  if (document.readyState === 'complete' || document.readyState === 'interactive') {
    return callback();
  }
  document.addEventListener('DOMContentLoaded', callback);
}
```
`document.readyState === 'complete'` is [just for IE 8](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState#Browser_compatibility) — which we don’t support. `document.readyState === 'interactive'` is for everything IE9+, but it also [happens in the same sequence as `DOMContentLoaded`](https://html.spec.whatwg.org/multipage/parsing.html#the-end) which is [supported by everything that is relevant](https://caniuse.com/#search=DOMContentLoaded).

I think `document.addEventListener('DOMContentLoaded', () => {});` is all we need.