### PR TITLE
Fix version_compare() operators

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -21,14 +21,14 @@ $sage_error = function ($message, $subtitle = '', $title = '') {
 /**
  * Ensure compatible version of PHP is used
  */
-if (version_compare('7.1.3', phpversion(), '>=')) {
+if (version_compare('7.1.3', phpversion(), '>')) {
     $sage_error(__('You must be using PHP 7.1.3 or greater.', 'sage'), __('Invalid PHP version', 'sage'));
 }
 
 /**
  * Ensure compatible version of WordPress is used
  */
-if (version_compare('5.2', get_bloginfo('version'), '>=')) {
+if (version_compare('5.2', get_bloginfo('version'), '>')) {
     $sage_error(__('You must be using WordPress 5.2 or greater.', 'sage'), __('Invalid WordPress version', 'sage'));
 }
 


### PR DESCRIPTION
I just noticed this, but even on Sage 9, our current use of `>=` on our conditionals would effectively make (in Sage 9's case) `7.1` and `4.7.0` return an error (as they would evaluate the conditional to `true`) even though they are supposed to be considered the supported minimums.

Using `>` instead fixes this issue, but as-is our use of `version_compare()` and it's operator are a little confusing at a glance. We should perhaps swap our required version and their current version in the function as seen [here](https://www.php.net/manual/en/function.version-compare.php) so we can use the `less than` sign instead.

Right now it kind of reads as "if `7.1.3` is greater than `phpversion()`" when instead it should read as "if `phpversion()` is less than `7.1.3`"