### PR TITLE
Fix npm run start script options not forwarded with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build": "cross-env NODE_ENV=development run-s mix",
     "build:production": "cross-env NODE_ENV=production run-s clean mix",
-    "start": "cross-env NODE_ENV=development run-s \"mix --watch\"",
+    "start": "cross-env NODE_ENV=development run-s \"mix -- --watch\"",
     "hot": "cross-env NODE_ENV=development run-s build mix:hot",
     "mix": "webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
     "mix:hot": "webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",


### PR DESCRIPTION
Previously mentioned here https://github.com/roots/sage/commit/f5c5d2844c438ba53e9571c67e96871a3b92b1e8#r33668278

This is a known difference between yarn and npm and will eventually break with yarn once backwards compatibility is removed.

Currently it will cause this warning with Yarn:

> warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.

Once Yarn removes the backwards compatibility this script will cause the following broken command to run:

```sh
webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js -- --watch
```

As this will eventually break I'm not sure if this the way to go but sending a PR so the issue is documented.

This behavior change was added in [Yarn 1.0.0](https://github.com/yarnpkg/yarn/releases/tag/v1.0.0) with PR https://github.com/yarnpkg/yarn/pull/4152 where there's some discussion regarding the matter.