### PR TITLE
add node_modules to scss test

### DIFF
--- a/resources/assets/build/webpack.config.js
+++ b/resources/assets/build/webpack.config.js
@@ -77,7 +77,7 @@ let webpackConfig = {
       },
       {
         test: /\.scss$/,
-        include: config.paths.assets,
+        include: [config.paths.assets, /node_modules/],
         use: ExtractTextPlugin.extract({
           fallback: 'style',
           use: [


### PR DESCRIPTION
adds node_modules based scss files to webpack. issue #2207

I'm not very conversant in Webpack so not sure if this could cause other issues, however it solved the issue I was having with scss references in node_modules libraries.