### PR TITLE
Use WordPress’ Browserslist config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "private": true,
   "browserslist": [
-    "defaults",
-    "not IE 11"
+    "extends @wordpress/browserslist-config"
   ],
   "scripts": {
     "build": "cross-env NODE_ENV=development run-s mix",
@@ -21,6 +20,7 @@
   },
   "devDependencies": {
     "@babel/plugin-syntax-dynamic-import": "^7.2",
+    "@wordpress/browserslist-config": "^2.5.0",
     "babel-eslint": "^10.0.2",
     "browser-sync": "^2.26",
     "browser-sync-webpack-plugin": "2.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "private": true,
+  "browserslist": [
+    "defaults",
+    "not IE 11"
+  ],
   "scripts": {
     "build": "cross-env NODE_ENV=development run-s mix",
     "build:production": "cross-env NODE_ENV=production run-s clean mix",

--- a/yarn.lock
+++ b/yarn.lock
@@ -867,6 +867,11 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
+"@wordpress/browserslist-config@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/browserslist-config/-/browserslist-config-2.5.0.tgz#f237750147b71f5a2c70bc9b43f3e3287218e9d3"
+  integrity sha512-cspE4iJ87YjweKAtnIsCxm7ZJQ/ved3TdRJWS0DX/0AOukoRhOMYh7CP1aVc0M3J1kB4LtTY7u3HOcqF2Yf2VA==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
A few tools we’re already using (Babel, Autoprefixer, Stylelint, ESlint) use Browserslist under the hood for their target browsers. I think explicitly setting it would be helpful for developers using Sage since it will encourage them to configure it themselves instead of relying on the invisible default setting ("defaults").

I’m using the `browserslist` key in `package.json` as the method since [it’s recommended](https://github.com/browserslist/browserslist#queries), however, we can always split this out to its own config file (`.browserslistrc`). I think the former is better since `package.json` is a heavily used file and it will make it very clear to the developer which browsers they are supporting. A file that lists dependencies also makes sense to provide a list of compile targets.

~~The query I’ve set also excludes IE 11 since I believe we were already doing so. You can see the list of supported browsers this includes:~~

~~https://browsersl.ist/?q=defaults%2C+not+IE+11~~

Something to note is that since we aren’t using the JS API for browserslist we do not need to include it as a (dev-)dependency for Sage.

A downside of explicitly adding this is that it may cause an increase in PRs in regards to what the defaults should be set to.