### PR TITLE
Fix broken source maps and remove unnecessary conditionals

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -51,11 +51,7 @@ mix.options({
 });
 
 // Source maps when not in production.
-if (!mix.inProduction()) {
-  mix.sourceMaps();
-}
+mix.sourceMaps(false, 'source-map');
 
 // Hash and version files in production.
-if (mix.inProduction()) {
-  mix.version();
-}
+mix.version();


### PR DESCRIPTION
Resolves #2266

Laravel Mix has a bug where source maps are not generated if you do not specify the source map type (the second argument). This corrects that.