### PR TITLE
Remove classic editor support

### DIFF
--- a/app/setup.php
+++ b/app/setup.php
@@ -73,12 +73,6 @@ add_action('after_setup_theme', function () {
      * @link https://developer.wordpress.org/themes/advanced-topics/customizer-api/#theme-support-in-sidebars
      */
     add_theme_support('customize-selective-refresh-widgets');
-
-    /**
-     * Use main stylesheet for visual editor
-     * @see resources/assets/styles/layouts/tinymce.scss
-     */
-    add_editor_style(asset('styles/app.css')->uri());
 }, 20);
 
 /**

--- a/resources/assets/styles/app.scss
+++ b/resources/assets/styles/app.scss
@@ -17,4 +17,3 @@
 @import 'layouts/footer';
 @import 'layouts/pages';
 @import 'layouts/posts';
-@import 'layouts/tinymce';

--- a/resources/assets/styles/layouts/tinymce.scss
+++ b/resources/assets/styles/layouts/tinymce.scss
@@ -1,7 +1,0 @@
-/**
- * TinyMCE
- */
-
-body#tinymce {
-  margin: 1rem !important;
-}


### PR DESCRIPTION
we’re not yet sure what kind of gutenberg integration will be included in sage 10, but we don’t want to include support for the classic editor out of the box

ref #2144 