### PR TITLE
Have nav menu return HTML when used within templating tags to echo

### DIFF
--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -3,7 +3,7 @@
     <a class="brand" href="{{ home_url('/') }}">{{ get_bloginfo('name', 'display') }}</a>
     <nav class="nav-primary">
       @if (has_nav_menu('primary_navigation'))
-        {!! wp_nav_menu(['theme_location' => 'primary_navigation', 'menu_class' => 'nav']) !!}
+        {!! wp_nav_menu(['theme_location' => 'primary_navigation', 'menu_class' => 'nav', 'echo' => false]) !!}
       @endif
     </nav>
   </div>


### PR DESCRIPTION
`wp_nav_menu()` will output by default. In the header example, the nav menu is inside echo template tags so it's echoing a function that already outputs directly. I've passed in an argument to have `wp_nav_menu()` return the menu instead . 

Alternatively it might make sense to just wrap it in @php as is done for things like `the_content()`.