### PR TITLE
Bump version of sage-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.8.0",
-    "roots/sage-installer": "~1.6"
+    "roots/sage-installer": "~1.6.3"
   },
   "scripts": {
     "test": ["phpcs"],


### PR DESCRIPTION
With this version bump, Sage will now correctly install the latest Tailwind version when you choose it as a preset during install. Currently all new Sage 9 projects would start you off with an old beta Tailwind release.