### PR TITLE
add phpstorm / idea, .DS_Store and sublimetext project files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /dist
 npm-debug.log
 yarn-error.log
+.DS_Store
+.idea
+*.sublime-workspace


### PR DESCRIPTION
Blocks the OSX .DS_Store, sublimetext and PHPStorm / idea project files from getting picked up by git.