### PR TITLE
Inline manifest.js when enqueueing editor.js

### DIFF
--- a/app/setup.php
+++ b/app/setup.php
@@ -42,6 +42,8 @@ add_action('enqueue_block_editor_assets', function () {
             $manifest['dependencies'],
             $manifest['version']
         );
+        
+        wp_add_inline_script('sage/editor.js', asset('scripts/manifest.js')->contents(), 'before');
     }
 
     wp_enqueue_style('sage/editor.css', asset('styles/editor.css')->uri(), false, null);


### PR DESCRIPTION
required by webpack if using `.extract()`