### PR TITLE
Bump node-sass to 4.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "imagemin-mozjpeg": "~7.0.0",
     "imagemin-webpack-plugin": "~2.2.0",
     "import-glob": "~1.5",
-    "node-sass": "~4.9.4",
+    "node-sass": "~4.12.0",
     "postcss-loader": "~2.1.0",
     "postcss-safe-parser": "~3.0",
     "resolve-url-loader": "~2.3.1",


### PR DESCRIPTION
I tried installing a fresh copy of Sage yesterday and got an error after running `yarn`. [Sage docs](https://roots.io/sage/docs/existing-sage-projects/), recommend using NodeJS LTS which is currently v12. The [minimum node-sass version](https://www.npmjs.com/package/node-sass) for Node 12 is now node-sass 4.12+. Error output attached.

[node-sass.txt](https://github.com/roots/sage/files/3998983/node-sass.txt)
