### PR TITLE
Fix vendor extracted js modules not available in editor.

### DIFF
--- a/app/setup.php
+++ b/app/setup.php
@@ -36,14 +36,15 @@ add_action('wp_enqueue_scripts', function () {
  */
 add_action('enqueue_block_editor_assets', function () {
     if ($manifest = asset('scripts/manifest.asset.php')->get()) {
+        wp_enqueue_script('sage/vendor.js', asset('scripts/vendor.js')->uri(), ['jquery'], null, true);
         wp_enqueue_script(
             'sage/editor.js',
             asset('scripts/editor.js')->uri(),
-            $manifest['dependencies'],
+            array_merge($manifest['dependencies'], ['sage/vendor.js']),
             $manifest['version']
         );
 
-        wp_add_inline_script('sage/editor.js', asset('scripts/manifest.js')->contents(), 'before');
+        wp_add_inline_script('sage/vendor.js', asset('scripts/manifest.js')->contents(), 'before');
     }
 
     wp_enqueue_style('sage/editor.css', asset('styles/editor.css')->uri(), false, null);


### PR DESCRIPTION
See #2370 

I know sage has always registered the scripts at the same time they're enqueued so this solution might not be great to everyone.

Another option is to somehow fix it in the laravel mix config I guess.