### PR TITLE
Keep hierarchical assets directory structure

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -26,8 +26,8 @@ mix.js('resources/assets/scripts/app.js', 'scripts')
    .blocks('resources/assets/scripts/editor.js', 'scripts')
    .extract();
 
-mix.copyWatched('resources/assets/images', 'dist/images', {base: 'resources/assets/images'})
-   .copyWatched('resources/assets/fonts', 'dist/fonts', {base: 'resources/assets/fonts'});
+mix.copyWatched('resources/assets/images/**', 'dist/images')
+   .copyWatched('resources/assets/fonts/**', 'dist/fonts');
 
 mix.autoload({
   jquery: ['$', 'window.jQuery'],

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -26,8 +26,8 @@ mix.js('resources/assets/scripts/app.js', 'scripts')
    .blocks('resources/assets/scripts/editor.js', 'scripts')
    .extract();
 
-mix.copyWatched('resources/assets/images', 'dist/images')
-   .copyWatched('resources/assets/fonts', 'dist/fonts');
+mix.copyWatched('resources/assets/images', 'dist/images', {base: 'resources/assets/images'})
+   .copyWatched('resources/assets/fonts', 'dist/fonts', {base: 'resources/assets/fonts'});
 
 mix.autoload({
   jquery: ['$', 'window.jQuery'],


### PR DESCRIPTION
### Issue summary

When organizing image and font assets in subdirectories their paths are flattened eg. `resources/assets/images/foo/bar.png` -> `dist/assets/images/bar.png`

With this PR it becomes `dist/assets/images/foo/bar.png`

### Solution

At first I thought this was a bug in the `laravel-mix-copy-watched` package ([invalid bug report](https://github.com/dsktschy/laravel-mix-copy-watched/issues/10)) but turns out it works as intended and keeping the hierarchy is actually an additional option.

I thought I'd open up a PR as others might encounter this as well. This is how it worked in sage 9, no?

Feel free to close this if you don't agree that this is a better default.