### PR TITLE
Fix tests / stylelint rules

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -5,6 +5,7 @@
     "value-list-comma-newline-after": null,
     "no-empty-source": null,
     "no-descending-specificity": null,
+    "at-rule-empty-line-before": null,
     "at-rule-no-unknown": [
       true,
       {

--- a/resources/assets/styles/common/global.scss
+++ b/resources/assets/styles/common/global.scss
@@ -6,11 +6,11 @@ a {
   color: map-get($theme-colors, 'primary');
 }
 
-
 /**
  * Block editor color palette utilities
  * @see https://git.io/JeyD6
  */
+
 @each $color-name, $color-value in $theme-colors {
   .has-#{$color-name}-color {
     color: $color-value;

--- a/resources/assets/styles/components/button.scss
+++ b/resources/assets/styles/components/button.scss
@@ -3,7 +3,6 @@
  */
 
 .wp-block-button {
-  // Base
   &__link {
     font-size: $btn-font-size;
     line-height: $btn-line-height;
@@ -17,7 +16,6 @@
     }
   }
 
-  // Button style: outline
   &.is-style-outline {
     .wp-block-button__link {
       @include button-outline-variant(
@@ -27,7 +25,6 @@
     }
   }
 
-  // Button style: solid
   &.is-style-solid {
     .wp-block-button__link {
       @include button-variant(

--- a/resources/assets/styles/components/index.scss
+++ b/resources/assets/styles/components/index.scss
@@ -1,1 +1,5 @@
+/**
+ * Components
+ */
+
 @import 'button';


### PR DESCRIPTION
- fix(stylelint): Fix broken tests 
- feat(stylelint): Set `at-rule-empty-line-before` to `null` to allow sane seperation of imports