### PR TITLE
Wrap mix version task with production conditional

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -37,5 +37,8 @@ mix.options({
   processCssUrls: false,
 });
 
-mix.sourceMaps(false, 'source-map')
-   .version();
+mix.sourceMaps(false, 'source-map');
+
+if (mix.inProduction()) {
+  mix.version();
+}


### PR DESCRIPTION
I had previously removed this (#2268) since from a quick glance at the actual Mix source code for the component, [it seemed that this task only ran in production](https://github.com/JeffreyWay/laravel-mix/blob/ddd3834eae01bb2d40fe186d8a72ab23d8830f51/src/components/Version.js#L31-L39). I have recently discovered that without the conditional, versioning indeed does take place in development (see the `mix-manifest.json`).