### PR TITLE
Add `Requires PHP` and `Requires at least`; Bump WordPress requirement to v5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ See a working example at [roots-example-project.com](https://roots-example-proje
 
 Make sure all dependencies have been installed before moving on:
 
-* [WordPress](https://wordpress.org/) >= 5.2
-* [PHP](https://secure.php.net/manual/en/install.php) >= 7.1.3 (with [`php-mbstring`](https://secure.php.net/manual/en/book.mbstring.php) enabled)
+* [WordPress](https://wordpress.org/) >= 5.4
+* [PHP](https://secure.php.net/manual/en/install.php) >= 7.2.0 (with [`php-mbstring`](https://secure.php.net/manual/en/book.mbstring.php) enabled)
 * [Composer](https://getcomposer.org/download/)
 * [Node.js](http://nodejs.org/) >= 8.0.0
 * [Yarn](https://yarnpkg.com/en/docs/install)

--- a/functions.php
+++ b/functions.php
@@ -19,20 +19,6 @@ $sage_error = function ($message, $subtitle = '', $title = '') {
 };
 
 /**
- * Ensure a compatible version of PHP is being used.
- */
-if (version_compare('7.2', phpversion(), '>')) {
-    $sage_error(__('You must be using PHP 7.2 or greater.', 'sage'), __('Invalid PHP version', 'sage'));
-}
-
-/**
- * Ensure a compatible version of WordPress is being used.
- */
-if (version_compare('5.2', get_bloginfo('version'), '>')) {
-    $sage_error(__('You must be using WordPress 5.2 or greater.', 'sage'), __('Invalid WordPress version', 'sage'));
-}
-
-/**
  * Ensure dependencies are loaded.
  */
 if (! file_exists($composer = __DIR__ . '/vendor/autoload.php')) {

--- a/style.css
+++ b/style.css
@@ -8,4 +8,6 @@ Author URI:         https://roots.io/
 Text Domain:        sage
 License:            MIT License
 License URI:        https://opensource.org/licenses/MIT
+Requires PHP:       7.2.0
+Requires at least:  5.4
 */


### PR DESCRIPTION
See: https://make.wordpress.org/core/2020/02/26/miscellaneous-developer-focused-changes-in-wordpress-5-4/