### PR TITLE
Use version_compare in order

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -21,14 +21,14 @@ $sage_error = function ($message, $subtitle = '', $title = '') {
 /**
  * Ensure a compatible version of PHP is being used.
  */
-if (version_compare('7.2', phpversion(), '>')) {
+if (version_compare(phpversion(), '7.2', '>=')) {
     $sage_error(__('You must be using PHP 7.2 or greater.', 'sage'), __('Invalid PHP version', 'sage'));
 }
 
 /**
  * Ensure a compatible version of WordPress is being used.
  */
-if (version_compare('5.2', get_bloginfo('version'), '>')) {
+if (version_compare(get_bloginfo('version'), '5.2', '>=')) {
     $sage_error(__('You must be using WordPress 5.2 or greater.', 'sage'), __('Invalid WordPress version', 'sage'));
 }
 


### PR DESCRIPTION
I didn't run into an issue until today, which is weird, but I'm getting a nonstop "You must be using PHP 7.2 or greater." even though I'm on 7.2.28. I looked into it and found that this version_compare is being called backwards! https://www.php.net/manual/en/function.version-compare.php. Also, I threw in a >= comparator because of the wording "5.2 or greater," "7.2 or greater"