### PR TITLE
Bump node-sass dependency to 4.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "imagemin-mozjpeg": "~7.0.0",
     "imagemin-webpack-plugin": "~2.2.0",
     "import-glob": "~1.5",
-    "node-sass": "~4.9.4",
+    "node-sass": "~4.13.1",
     "postcss-loader": "~2.1.0",
     "postcss-safe-parser": "~3.0",
     "resolve-url-loader": "~2.3.1",


### PR DESCRIPTION
node-sass ~4.9.4 will fail on certain environments. This will simply bump the version to node-sass@latest (4.13.1) which corrects the issue.

Error: Node Sass does not yet support your current environment: OS X 64-bit with Unsupported runtime (72)