### PR TITLE
Add html and body to PurgeCSS whitelist

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -20,7 +20,7 @@ mix.setPublicPath('./dist')
 mix.sass('resources/assets/styles/app.scss', 'styles')
    .sass('resources/assets/styles/editor.scss', 'styles')
    .purgeCss({
-     whitelist: require('purgecss-with-wordpress').whitelist,
+     whitelist: ['html', 'body', require('purgecss-with-wordpress').whitelist],
      whitelistPatterns: require('purgecss-with-wordpress').whitelistPatterns,
    });
 


### PR DESCRIPTION
Purgecss removes styling for html and body which will have an impact of normalise/resets, add both to whitelist. https://github.com/FullHuman/purgecss-webpack-plugin/issues/69