### PR TITLE
Check for autoload.php in root vendor

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,7 +11,10 @@
 |
 */
 
-if (! file_exists($composer = __DIR__ . '/vendor/autoload.php')) {
+if (
+    ! file_exists($composer = __DIR__ . '/vendor/autoload.php')
+    && ! file_exists($composer = dirname(__DIR__, 4) . '/vendor/autoload.php')
+) {
     wp_die(__('Error locating autoloader. Please run <code>composer install</code>.', 'sage'));
 }
 


### PR DESCRIPTION
Check for autoload.php not only in local vendor folder, but also in vendor folder inside Bedrock page root.
Requires roots/acorn/pull/75