### PR TITLE
Fix Bootstrap version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Sage is a productivity-driven WordPress starter theme with a modern development 
 - Harness the power of [Laravel](https://laravel.com) and its available packages thanks to [Acorn](https://github.com/roots/acorn).
 - Clean, efficient theme templating utilizing [Laravel Blade](https://laravel.com/docs/latest/blade).
 - Easy [Browsersync](http://www.browsersync.io/) support alongside asset compilation, concatenating, and minification powered by [Laravel Mix](https://github.com/JeffreyWay/laravel-mix).
-- Out of the box support for [Bootstrap 5](https://getbootstrap.com/) and [jQuery](https://jquery.com).
+- Out of the box support for [Bootstrap 4](https://getbootstrap.com/) and [jQuery](https://jquery.com).
 - A clean starting point for theme styles using [Sass](https://sass-lang.com/).
 
 See a working example at [roots-example-project.com](https://roots-example-project.com/).


### PR DESCRIPTION
Since the current (available) version of Bootstrap is `4.5`, I think that `Bootstrap 5` wasn´t meant.