### PR TITLE
Correct "trailingComma" value for prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   "semi": true,
   "singleQuote": true,
-  "trailingComma": true
+  "trailingComma": "es5"
 }


### PR DESCRIPTION
For "trailingComma" in `.prettierrc`, the value "true" is not accepted. Valid values are: "es5", "none", "all" https://prettier.io/docs/en/options.html#trailing-commas