### PR TITLE
[9.x] Add 'config.enabled.browserSync' option to build config

### DIFF
--- a/resources/assets/build/config.js
+++ b/resources/assets/build/config.js
@@ -26,6 +26,7 @@ const config = merge({
     optimize: isProduction,
     cacheBusting: isProduction,
     watcher: !!argv.watch,
+    browserSync: !!argv.watch,
   },
   watch: [],
 }, userConfig);

--- a/resources/assets/build/webpack.config.js
+++ b/resources/assets/build/webpack.config.js
@@ -151,7 +151,7 @@ let webpackConfig = {
     new ExtractTextPlugin({
       filename: `styles/${assetsFilenames}.css`,
       allChunks: true,
-      disable: (config.enabled.watcher),
+      disable: (config.enabled.watcher && config.enabled.browserSync),
     }),
     new webpack.ProvidePlugin({
       $: 'jquery',
@@ -209,7 +209,7 @@ if (config.enabled.cacheBusting) {
   );
 }
 
-if (config.enabled.watcher) {
+if (config.enabled.watcher && config.enabled.browserSync) {
   webpackConfig.entry = require('./util/addHotMiddleware')(webpackConfig.entry);
   webpackConfig = merge(webpackConfig, require('./webpack.config.watch'));
 }


### PR DESCRIPTION
This is a redo of https://github.com/roots/sage/pull/2418, cleaned up and rebased on the 9.x branch.

----

This adds a configuration option to disable BrowserSync (and Wepack HMR) and support a more basic "watch and manually refresh" kind of workflow.


**Example**

In `resources/assets/config.json`, add:

```
  "enabled": {
    "browserSync": false
  }
```

Run `yarn start`:

![yarn-start](https://user-images.githubusercontent.com/7805679/75888939-2019f280-5dfa-11ea-98cd-33204541837b.png)


Update something in `resources/assets/styles/main.scss`:

![update-main-scss](https://user-images.githubusercontent.com/7805679/75888957-25773d00-5dfa-11ea-9d06-71326b49fc4a.png)

