### PR TITLE
Fix/add translators comment

### DIFF
--- a/app/View/Composers/Post.php
+++ b/app/View/Composers/Post.php
@@ -53,8 +53,8 @@ class Post extends Composer
         }
 
         if (is_search()) {
-            /* translators: %s is replaced with the search query */
             return sprintf(
+                /* translators: %s is replaced with the search query */
                 __('Search Results for %s', 'sage'),
                 get_search_query()
             );

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -29,6 +29,7 @@ collect(['helpers', 'setup', 'filters', 'admin'])
     ->each(function ($file) {
         if (! locate_template($file = "app/{$file}.php", true, true)) {
             wp_die(
+                /* translators: %s is replaced with relative file path */
                 sprintf(__('Error locating <code>%s</code> for inclusion.', 'sage'), $file)
             );
         }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -29,7 +29,7 @@ collect(['helpers', 'setup', 'filters', 'admin'])
     ->each(function ($file) {
         if (! locate_template($file = "app/{$file}.php", true, true)) {
             wp_die(
-                /* translators: %s is replaced with relative file path */
+                /* translators: %s is replaced with the relative file path */
                 sprintf(__('Error locating <code>%s</code> for inclusion.', 'sage'), $file)
             );
         }


### PR DESCRIPTION
In current Sage master, when invoking the `translate` (`translate:pot`) script, `wp i18n make-pot` emits warnings for missing translator comments of code used in the Sage theme:
- `Warning: The string "Search Results for %s" contains placeholders but has no "translators:" comment to clarify their meaning. (app/View/Composers/Post.php:58)`
- `Warning: The string "Error locating <code>%s</code> for inclusion." contains placeholders but has no "translators:" comment to clarify their meaning. (bootstrap/app.php:32)`

In case of `app/View/Composers/Post.php:58` there is already a `translator` comment, but on the wrong line, as `wp i18n make-pot` only uses those when directly preceding the translation methods, this PR fixes this.

In case of `bootstrap/app.php:32` the `translator` comment is completely missing and added by this PR.