### PR TITLE
Make jQuery 3.5.1 a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "stylelint-config-standard": "^20.0.0",
     "tailwindcss": "^2.0.3"
   },
-  "dependencies": {
+  "peerDependencies": {
     "jquery": "^3.5.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4826,11 +4826,6 @@ jest-worker@^26.6.2:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jquery@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
Since Sage is relying on WordPress’ jQuery, we can save the user from needing to download it.