### PR TITLE
Remove redundant x-ua-compatible meta tag

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,7 +2,6 @@
 <html <?php language_attributes(); ?>>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <?php wp_head(); ?>
   </head>


### PR DESCRIPTION
This is redundant for IE 11.
