### PR TITLE
Fix development instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Edit `app/setup.php` to enable or disable theme features, setup navigation menus
 
 - Run `yarn` from the theme directory to install dependencies
 - Update `webpack.mix.js` with your local dev URL
+- Add to wp-config.php `define('WP_ENV', 'development');`
 
 ### Build commands
 


### PR DESCRIPTION
Without `WP_ENV` defined, we get white screen on php errors.

This constant is used in config/app.php.

fixes #2656