### PR TITLE
fix(lint): Add additional known at-rules

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -29,7 +29,10 @@
           "responsive",
           "variants",
           "screen",
-          "function"
+          "function",
+          "use",
+          "forward",
+          "layer"
         ]
       }
     ]


### PR DESCRIPTION
Fixes linting errors when using  `@use`, `@forward` or `@layer` in a `.scss` file.