### PR TITLE
Improve primary_navigation menu location

### DIFF
--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -4,7 +4,7 @@
   </a>
 
   @if (has_nav_menu('primary_navigation'))
-    <nav class="nav-primary">
+    <nav class="nav-primary" aria-label="{{wp_get_nav_menu_name('primary_navigation')}}">
       {!! wp_nav_menu(['theme_location' => 'primary_navigation', 'menu_class' => 'nav', 'echo' => false]) !!}
     </nav>
   @endif


### PR DESCRIPTION
This pull request improves the `primary_navigation` menu location in two ways. First, the `<nav>` element is no longer displayed if nothing is set the menu location. Previously, the contents of the element were conditionally displayed. There’s no point in displaying the element if it’s empty. Second, this menu location now uses the menu name set by the user as the accessible name of the `<nav>` element. I am using `aria-label` rather than `aria-labelledby` (with a hidden element as the label) since [the prior issues with translating `aria-label` in Chrome](https://adrianroselli.com/2019/11/aria-label-does-not-translate.html) have been resolved.
