### PR TITLE
feat(theme-wrapper): remove `shrink-to-fit=no`

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 <html <?php language_attributes(); ?>>
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <?php wp_head(); ?>
   </head>
 


### PR DESCRIPTION
Sounds like this was only needed from about iOS 9.0-9.3.2 (see articles for a more accurate range).

See:

- https://www.matuzo.at/blog/html-boilerplate/
- https://www.scottohara.me/blog/2018/12/11/shrink-to-fit.html
- HTML 5 Boilerplate