### PR TITLE
Use type declarations and bump minimum PHP version to 7.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     strategy:
       matrix:
-        php: ['7.3', '7.4', '8.0']
+        php: ['7.4', '8.0', '8.1']
 
     steps:
       - name: Checkout the project

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Sage is a productivity-driven WordPress starter theme with a modern development 
 Make sure all dependencies have been installed before moving on:
 
 - [WordPress](https://wordpress.org/) >= 5.4
-- [PHP](https://secure.php.net/manual/en/install.php) >= 7.3.0 (with [`php-mbstring`](https://secure.php.net/manual/en/book.mbstring.php) enabled)
+- [PHP](https://secure.php.net/manual/en/install.php) >= 7.4.0 (with [`php-mbstring`](https://secure.php.net/manual/en/book.mbstring.php) enabled)
 - [Composer](https://getcomposer.org/download/)
 - [Node.js](http://nodejs.org/) >= 16
 - [Yarn](https://yarnpkg.com/en/docs/install)

--- a/app/Providers/ThemeServiceProvider.php
+++ b/app/Providers/ThemeServiceProvider.php
@@ -8,20 +8,16 @@ class ThemeServiceProvider extends ServiceProvider
 {
     /**
      * Register any application services.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         //
     }
 
     /**
      * Bootstrap any application services.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         //
     }

--- a/app/View/Components/Alert.php
+++ b/app/View/Components/Alert.php
@@ -2,6 +2,8 @@
 
 namespace App\View\Components;
 
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
 use Roots\Acorn\View\Component;
 
 class Alert extends Component
@@ -11,21 +13,21 @@ class Alert extends Component
      *
      * @var string
      */
-    public $type;
+    public string $type;
 
     /**
      * The alert message.
      *
      * @var string
      */
-    public $message;
+    public string $message;
 
     /**
      * The alert types.
      *
      * @var array
      */
-    public $types = [
+    public array $types = [
         'default' => 'text-indigo-50 bg-indigo-400',
         'success' => 'text-green-50 bg-green-400',
         'caution' => 'text-yellow-50 bg-yellow-400',
@@ -34,12 +36,8 @@ class Alert extends Component
 
     /**
      * Create the component instance.
-     *
-     * @param  string  $type
-     * @param  string  $message
-     * @return void
      */
-    public function __construct($type = 'default', $message = null)
+    public function __construct(string $type = 'default', ?string $message = null)
     {
         $this->type = $this->types[$type] ?? $this->types['default'];
         $this->message = $message;
@@ -48,7 +46,7 @@ class Alert extends Component
     /**
      * Get the view / contents that represent the component.
      *
-     * @return \Illuminate\View\View|string
+     * @return Factory|View
      */
     public function render()
     {

--- a/app/View/Composers/App.php
+++ b/app/View/Composers/App.php
@@ -9,7 +9,7 @@ class App extends Composer
     /**
      * List of views served by this composer.
      *
-     * @var array
+     * @var string[]
      */
     protected static $views = [
         '*',
@@ -17,10 +17,8 @@ class App extends Composer
 
     /**
      * Data to be passed to view before rendering.
-     *
-     * @return array
      */
-    public function with()
+    public function with(): array
     {
         return [
             'siteName' => $this->siteName(),
@@ -29,10 +27,8 @@ class App extends Composer
 
     /**
      * Returns the site name.
-     *
-     * @return string
      */
-    public function siteName()
+    public function siteName(): string
     {
         return get_bloginfo('name', 'display');
     }

--- a/app/View/Composers/Post.php
+++ b/app/View/Composers/Post.php
@@ -9,7 +9,7 @@ class Post extends Composer
     /**
      * List of views served by this composer.
      *
-     * @var array
+     * @var string[]
      */
     protected static $views = [
         'partials.page-header',
@@ -19,10 +19,8 @@ class Post extends Composer
 
     /**
      * Data to be passed to view before rendering, but after merging.
-     *
-     * @return array
      */
-    public function override()
+    public function override(): array
     {
         return [
             'title' => $this->title(),
@@ -31,10 +29,8 @@ class Post extends Composer
 
     /**
      * Returns the post title.
-     *
-     * @return string
      */
-    public function title()
+    public function title(): string
     {
         if ($this->view->name() !== 'partials.page-header') {
             return get_the_title();

--- a/app/admin.php
+++ b/app/admin.php
@@ -12,11 +12,8 @@ use function Roots\bundle;
 
 /**
  * Register the `.brand` selector to the blogname.
- *
- * @param  \WP_Customize_Manager $wp_customize
- * @return void
  */
-add_action('customize_register', function (WP_Customize_Manager $wp_customize) {
+add_action('customize_register', function (WP_Customize_Manager $wp_customize): void {
     $wp_customize->get_setting('blogname')->transport = 'postMessage';
     $wp_customize->selective_refresh->add_partial('blogname', [
         'selector' => '.brand',
@@ -28,9 +25,7 @@ add_action('customize_register', function (WP_Customize_Manager $wp_customize) {
 
 /**
  * Register the customizer assets.
- *
- * @return void
  */
-add_action('customize_preview_init', function () {
+add_action('customize_preview_init', function (): void {
     bundle('customizer')->enqueueJs(true, ['customize-preview']);
 });

--- a/app/filters.php
+++ b/app/filters.php
@@ -8,9 +8,7 @@ namespace App;
 
 /**
  * Add "… Continued" to the excerpt.
- *
- * @return string
  */
-add_filter('excerpt_more', function () {
+add_filter('excerpt_more', function (): string {
     return sprintf(' &hellip; <a href="%s">%s</a>', get_permalink(), __('Continued', 'sage'));
 });

--- a/app/setup.php
+++ b/app/setup.php
@@ -10,28 +10,22 @@ use function Roots\bundle;
 
 /**
  * Register the theme assets.
- *
- * @return void
  */
-add_action('wp_enqueue_scripts', function () {
+add_action('wp_enqueue_scripts', function (): void {
     bundle('app')->enqueue();
 }, 100);
 
 /**
  * Register the theme assets with the block editor.
- *
- * @return void
  */
-add_action('enqueue_block_editor_assets', function () {
+add_action('enqueue_block_editor_assets', function (): void {
     bundle('editor')->enqueue();
 }, 100);
 
 /**
  * Register the initial theme setup.
- *
- * @return void
  */
-add_action('after_setup_theme', function () {
+add_action('after_setup_theme', function (): void {
     /**
      * Enable features from the Soil plugin if activated.
      * @link https://roots.io/plugins/soil/
@@ -168,7 +162,7 @@ add_action('after_setup_theme', function () {
  *
  * @return void
  */
-add_action('widgets_init', function () {
+add_action('widgets_init', function (): void {
     $config = [
         'before_widget' => '<section class="widget %1$s %2$s">',
         'after_widget' => '</section>',

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     }
   },
   "require": {
-    "php": "^7.3|^8.0",
+    "php": "^7.4|^8.0",
     "roots/acorn": "2.0.0-beta.5"
   },
   "require-dev": {

--- a/style.css
+++ b/style.css
@@ -8,6 +8,6 @@ Author URI:         https://roots.io/
 Text Domain:        sage
 License:            MIT License
 License URI:        https://opensource.org/licenses/MIT
-Requires PHP:       7.3
+Requires PHP:       7.4
 Requires at least:  5.4
 */


### PR DESCRIPTION
This PR uses type declarations that are supported by PHP 7.4+ where it and therefore increases the project’s supported PHP version to 7.4.

Ref https://github.com/roots/bedrock/pull/619:

> PHP 7.3 EOL is 2021-12-06 
> https://www.php.net/supported-versions.php

