### PR TITLE
chore(deps): Bump roots/acorn to v2.0.0-beta.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   },
   "require": {
     "php": "^7.3|^8.0",
-    "roots/acorn": "2.0.0-beta.5"
+    "roots/acorn": "v2.0.0-beta.6"
   },
   "require-dev": {
     "filp/whoops": "^2.12",


### PR DESCRIPTION
closes #2852

ref https://github.com/roots/acorn/releases/tag/v2.0.0-beta.6