### PR TITLE
Remove JavaScript detection using class names

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,7 +6,7 @@
     <?php wp_head(); ?>
   </head>
 
-  <body <?php body_class('no-js'); ?>>
+  <body <?php body_class(); ?>>
     <?php wp_body_open(); ?>
     <?php do_action('get_header'); ?>
 

--- a/resources/scripts/app.js
+++ b/resources/scripts/app.js
@@ -1,12 +1,10 @@
 import {domReady} from '@scripts/components';
 
 /**
- * Remove `.no-js` from document body
- * when DOM has loaded.
+ * Run the application when the DOM is ready.
  */
 domReady(() => {
-  document.body.classList.contains('no-js') &&
-    document.body.classList.remove('no-js');
+  // Application code.
 });
 
 /**


### PR DESCRIPTION
This PR took a bit of a turn. Originally, it moved existing JavaScript detection from the `body` to the `html` element as well as the code to do that to the `index.php` file. After some feedback and further research, I began to question the necessity of the JavaScript detection in the first place. I struggled to find websites that actually used JavaScript detection with a class name on `html` or `body` and when they did there was no code on the site that actually used the class name for any non-JS or enhanced effect.

I’m convinced that this method has lost favour to progressive enhancement methods which emphasize writing styles that work for HTML out of the box. In these methods, increased specificity (e.g. the targeting the presence of attributes) is used to style components when they are enhanced with JavaScript. An example of this in practice might be web components that dynamically import and adopt their stylesheet upon registration. The philosophy here is to allow browsers that want to work less, to do so instead of working more (e.g. writing `.no-js` styles that override fully enhanced component styles).