### PR TITLE
chore: remove helpers.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ themes/your-theme-name/   # → Root of your Sage based theme
 │   ├── Providers/        # → Service providers
 │   ├── View/             # → View models
 │   ├── filters.php       # → Theme filters
-│   ├── helpers.php       # → Helper functions
 │   └── setup.php         # → Theme setup
 ├── composer.json         # → Autoloading for `app/` files
 ├── public/               # → Built theme assets (never edit)

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,7 +1,0 @@
-<?php
-
-/**
- * Theme helpers.
- */
-
-namespace App;

--- a/functions.php
+++ b/functions.php
@@ -43,7 +43,7 @@ require $composer;
 |
 */
 
-collect(['helpers', 'setup', 'filters'])
+collect(['setup', 'filters'])
     ->each(function ($file) {
         if (! locate_template($file = "app/{$file}.php", true, true)) {
             wp_die(


### PR DESCRIPTION
I've removed this on every project I've made with Sage 10 up to this point as I can't really find a reason I'd use a messy global function over using a method inside of a Composer, a trait, or my own class.

Thoughts?