### PR TITLE
Ignore `storage/` directory by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /node_modules
 /vendor
 /public
+/storage
 .env
 .budfiles
 npm-debug.log


### PR DESCRIPTION
The `storage/` directory in the theme directory is currently not ignored by git (not listed in `.gitignore`).
This is especially an issue with the `framework/views/` subdirectory of it as it contains cached runtime files (blade templates rendered as PHP files).

As the whole `storage/` directory appears to be used for runtime/theme application state, 
it should be completely ignored from VCS/git - or does it contain things that should also be versioned?