### PR TITLE
Dynamically set the Bud public path

### DIFF
--- a/bud.config.js
+++ b/bud.config.js
@@ -42,4 +42,4 @@ module.exports = (app) =>
     /**
      * Public path of application assets
      */
-    .setPublicPath('/app/themes/sage/public/');
+    .setPublicPath(__dirname + '/public/');


### PR DESCRIPTION
In the upgrade to Bud 5.1.0, the Bud public path was hardcoded as `/app/themes/sage/public/`.

Instead of requiring people to manually set their path, we should just build it from the location of the Bud config file using Node's `__dirname`.