### PR TITLE
chore(header): allow unescaped siteName data

### DIFF
--- a/resources/views/sections/header.blade.php
+++ b/resources/views/sections/header.blade.php
@@ -1,6 +1,6 @@
 <header class="banner">
   <a class="brand" href="{{ home_url('/') }}">
-    {{ $siteName }}
+    {!! $siteName !!}
   </a>
 
   @if (has_nav_menu('primary_navigation'))


### PR DESCRIPTION
Hello,

Just a quick fix but I often come across it

When the title of our site contains the character &.

On the site side, it displays `&amp;`.