### PR TITLE
⬆️ bump roots/acorn to v2.0.0-beta.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   },
   "require": {
     "php": "^7.4|^8.0",
-    "roots/acorn": "v2.0.0-beta.8"
+    "roots/acorn": "v2.0.0-beta.9"
   },
   "require-dev": {
     "filp/whoops": "^2.12",


### PR DESCRIPTION
https://github.com/roots/acorn/releases/tag/v2.0.0-beta.9

closes #2946