### PR TITLE
🩹 tmp fix dev asset path

### DIFF
--- a/bud.config.js
+++ b/bud.config.js
@@ -36,4 +36,8 @@ module.exports = (app) =>
      *
      * This is your local dev server.
      */
-    .proxy('http://example.test');
+    .proxy('http://example.test')
+    .when(
+      app.isDevelopment,
+      (app) => app.setPublicPath('app/themes/sage/public/')
+    );


### PR DESCRIPTION
the current bud + acorn combo is returning broken URLs when using the `@asset` directive:

1. add `example.svg` to `resources/images/`
2. use `@asset/images/example.svg` in a blade
3. run `yarn dev`

### resulting `@asset` path:

```
//localhost:3000//images/example.svg
```

### expected `@asset` path:

```
//localhost:3000/app/themes/sage/public/images/example.svg
```

### temporary `@asset` path with this PR:

```
//localhost:3000//app/themes/sage/public/images/example.svg
```