### PR TITLE
bud 5.4.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: [require.resolve('@roots/sage/eslint-config')],
+  extends: ['@roots/eslint-config/sage'],
 };

--- a/bud.config.js
+++ b/bud.config.js
@@ -11,15 +11,15 @@ module.exports = (app) =>
      * Paths are relative to your resources directory
      */
     .entry({
-      app: ['scripts/app.js', 'styles/app.css'],
-      editor: ['scripts/editor.js', 'styles/editor.css'],
+      app: ['@scripts/app', '@styles/app'],
+      editor: ['@scripts/editor', '@styles/editor'],
     })
 
     /**
      * These files should be processed as part of the build
      * even if they are not explicitly imported in application assets.
      */
-    .assets(['images'])
+    .assets('@images')
 
     /**
      * These files will trigger a full page reload
@@ -36,4 +36,4 @@ module.exports = (app) =>
      *
      * This is your local dev server.
      */
-    .proxy('http://example.test');
+    .proxy('http://tinypixel.sabo');

--- a/bud.config.js
+++ b/bud.config.js
@@ -3,7 +3,7 @@
  *
  * @param {bud} app
  */
-module.exports = (app) =>
+module.exports = async (app) => {
   app
     /**
      * Application entrypoints
@@ -19,7 +19,7 @@ module.exports = (app) =>
      * These files should be processed as part of the build
      * even if they are not explicitly imported in application assets.
      */
-    .assets('@images')
+    .assets('images')
 
     /**
      * These files will trigger a full page reload
@@ -36,4 +36,10 @@ module.exports = (app) =>
      *
      * This is your local dev server.
      */
-    .proxy('http://tinypixel.sabo');
+    .proxy('http://example.test')
+
+    /**
+     * Development URL
+     */
+    .serve('http://example.test:3000');
+};

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,15 +1,14 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
+    "jsx": "preserve",
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "commonjs",
     "moduleResolution": "node",
     "paths": {
       "@scripts/*": ["./resources/scripts/*"],
       "@styles/*": ["./resources/styles/*"]
-    },
-    "target": "es5"
+    }
   },
-  "exclude": ["./public"]
+  "exclude": ["./public", "./node_modules"]
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "@roots/bud": "0.0.0",
     "@roots/bud-eslint": "0.0.0",
-    "@roots/bud-postcss": "0.0.0",
     "@roots/bud-prettier": "0.0.0",
     "@roots/bud-stylelint": "0.0.0",
     "@roots/bud-tailwindcss": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "translate:js": "wp i18n make-json ./resources/lang --pretty-print"
   },
   "devDependencies": {
-    "@roots/bud": "0.0.0",
-    "@roots/bud-eslint": "0.0.0",
-    "@roots/bud-prettier": "0.0.0",
-    "@roots/bud-stylelint": "0.0.0",
-    "@roots/bud-tailwindcss": "0.0.0",
-    "@roots/eslint-config": "0.0.0",
-    "@roots/sage": "0.0.0"
+    "@roots/bud": "5.4.0",
+    "@roots/bud-eslint": "5.4.0",
+    "@roots/bud-prettier": "5.4.0",
+    "@roots/bud-stylelint": "5.4.0",
+    "@roots/bud-tailwindcss": "5.4.0",
+    "@roots/eslint-config": "5.4.0",
+    "@roots/sage": "5.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,6 @@
 {
   "name": "sage",
   "private": true,
-  "bud": {
-    "location": {
-      "src": "resources",
-      "dist": "public"
-    }
-  },
   "browserslist": [
     "extends @wordpress/browserslist-config"
   ],
@@ -25,12 +19,13 @@
     "translate:js": "wp i18n make-json ./resources/lang --pretty-print"
   },
   "devDependencies": {
-    "@roots/bud": "5.3.2",
-    "@roots/bud-eslint": "5.3.2",
-    "@roots/bud-postcss": "5.3.2",
-    "@roots/bud-prettier": "5.3.2",
-    "@roots/bud-stylelint": "5.3.2",
-    "@roots/bud-tailwindcss": "5.3.2",
-    "@roots/sage": "5.3.2"
+    "@roots/bud": "0.0.0",
+    "@roots/bud-eslint": "0.0.0",
+    "@roots/bud-postcss": "0.0.0",
+    "@roots/bud-prettier": "0.0.0",
+    "@roots/bud-stylelint": "0.0.0",
+    "@roots/bud-tailwindcss": "0.0.0",
+    "@roots/eslint-config": "0.0.0",
+    "@roots/sage": "0.0.0"
   }
 }

--- a/resources/scripts/app.js
+++ b/resources/scripts/app.js
@@ -1,15 +1,21 @@
 import {domReady} from '@roots/sage/client';
 
 /**
- * Run the application when the DOM is ready.
+ * app.main
  */
-domReady(() => {
-  // Application code.
-});
+const main = async (err) => {
+  if (err) {
+    // handle hmr errors
+    console.error(err);
+  }
+
+  // application code
+};
 
 /**
- * Accept module updates
+ * Initialize
  *
  * @see https://webpack.js.org/api/hot-module-replacement
  */
-import.meta.webpackHot?.accept(console.error);
+domReady(main);
+import.meta.webpackHot?.accept(main);

--- a/resources/scripts/editor.js
+++ b/resources/scripts/editor.js
@@ -1,22 +1,27 @@
+import {domReady} from '@roots/sage/client';
 import {registerBlockStyle, unregisterBlockStyle} from '@wordpress/blocks';
 
-import {domReady} from '@roots/sage/client';
-
 /**
- * Customize block styles
+ * editor.main
  */
-domReady(() => {
+const main = (err) => {
+  if (err) {
+    // handle hmr errors
+    console.error(err);
+  }
+
   unregisterBlockStyle('core/button', 'outline');
 
   registerBlockStyle('core/button', {
     name: 'outline',
     label: 'Outline',
   });
-});
+};
 
 /**
- * Accept module updates
+ * Initialize
  *
  * @see https://webpack.js.org/api/hot-module-replacement
  */
-import.meta.webpackHot?.accept(console.error);
+domReady(main);
+import.meta.webpackHot?.accept(main);

--- a/theme.json
+++ b/theme.json
@@ -22,14 +22,7 @@
     },
     "spacing": {
       "padding": true,
-      "units": [
-        "px",
-        "%",
-        "em",
-        "rem",
-        "vw",
-        "vh"
-      ]
+      "units": ["px", "%", "em", "rem", "vw", "vh"]
     },
     "typography": {
       "customFontSize": false

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,6 +980,14 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
+"@csstools/postcss-color-function@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-1.0.2.tgz#0843fe19be08eeb22e5d2242a6ac06f8b87b9ed2"
+  integrity sha512-uayvFqfa0hITPwVduxRYNL9YBD/anTqula0tu2llalaxblEd7QPuETSN3gB5PvTYxSfd0d8kS4Fypgo5JaUJ6A==
+  dependencies:
+    "@csstools/postcss-progressive-custom-properties" "^1.1.0"
+    postcss-value-parser "^4.2.0"
+
 "@csstools/postcss-font-format-keywords@^1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@csstools/postcss-font-format-keywords/-/postcss-font-format-keywords-1.0.0.tgz#7e7df948a83a0dfb7eb150a96e2390ac642356a1"
@@ -992,6 +1000,14 @@
   resolved "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-1.0.0.tgz#d6785c1c5ba8152d1d392c66f3a6a446c6034f6d"
   integrity sha512-VSTd7hGjmde4rTj1rR30sokY3ONJph1reCBTUXqeW1fKwETPy1x4t/XIeaaqbMbC5Xg4SM/lyXZ2S8NELT2TaA==
   dependencies:
+    postcss-value-parser "^4.2.0"
+
+"@csstools/postcss-ic-unit@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-1.0.0.tgz#f484db59fc94f35a21b6d680d23b0ec69b286b7f"
+  integrity sha512-i4yps1mBp2ijrx7E96RXrQXQQHm6F4ym1TOD0D69/sjDjZvQ22tqiEvaNw7pFZTUO5b9vWRHzbHzP9+UKuw+bA==
+  dependencies:
+    "@csstools/postcss-progressive-custom-properties" "^1.1.0"
     postcss-value-parser "^4.2.0"
 
 "@csstools/postcss-is-pseudo-class@^2.0.0":
@@ -1008,19 +1024,34 @@
   dependencies:
     postcss-value-parser "^4.2.0"
 
+"@csstools/postcss-oklab-function@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-1.0.1.tgz#a12348eae202d4ded908a06aa92cf19a946b6cec"
+  integrity sha512-Bnly2FWWSTZX20hDJLYHpurhp1ot+ZGvojLOsrHa9frzOVruOv4oPYMZ6wQomi9KsbZZ+Af/CuRYaGReTyGtEg==
+  dependencies:
+    "@csstools/postcss-progressive-custom-properties" "^1.1.0"
+    postcss-value-parser "^4.2.0"
+
+"@csstools/postcss-progressive-custom-properties@^1.1.0", "@csstools/postcss-progressive-custom-properties@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-1.2.0.tgz#7d53b773de50874c3885918dcb10cac97bf66ed5"
+  integrity sha512-YLpFPK5OaLIRKZhUfnrZPT9s9cmtqltIOg7W6jPcxmiDpnZ4lk+odfufZttOAgcg6IHWvNLgcITSLpJxIQB/qQ==
+  dependencies:
+    postcss-value-parser "^4.2.0"
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.6"
   resolved "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz"
   integrity sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==
 
-"@eslint/eslintrc@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz"
-  integrity sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==
+"@eslint/eslintrc@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz#583d12dbec5d4f22f333f9669f7d0b7c7815b4d3"
+  integrity sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
-    espree "^9.2.0"
+    espree "^9.3.1"
     globals "^13.9.0"
     ignore "^4.0.6"
     import-fresh "^3.2.1"
@@ -1074,51 +1105,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@oclif/core@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.npmjs.org/@oclif/core/-/core-1.3.3.tgz#d115a4aa2f80cf0b1f529f2cf5fd8f65950b030e"
-  integrity sha512-vekr36NDJnrNy6zB4DOm61nZWDoXRqAFFgGsobgLwTBcjnyDqqEAIwD5NET/F0JUjM1kaEs/jr8knHjmUSrAQg==
-  dependencies:
-    "@oclif/linewrap" "^1.0.0"
-    "@oclif/screen" "^3.0.2"
-    ansi-escapes "^4.3.0"
-    ansi-styles "^4.2.0"
-    cardinal "^2.1.1"
-    chalk "^4.1.2"
-    clean-stack "^3.0.1"
-    cli-progress "^3.10.0"
-    debug "^4.3.3"
-    ejs "^3.1.6"
-    fs-extra "^9.1.0"
-    get-package-type "^0.1.0"
-    globby "^11.0.4"
-    hyperlinker "^1.0.0"
-    indent-string "^4.0.0"
-    is-wsl "^2.2.0"
-    js-yaml "^3.13.1"
-    lodash "^4.17.21"
-    natural-orderby "^2.0.3"
-    object-treeify "^1.1.4"
-    password-prompt "^1.1.2"
-    semver "^7.3.5"
-    string-width "^4.2.3"
-    strip-ansi "^6.0.1"
-    supports-color "^8.1.1"
-    supports-hyperlinks "^2.2.0"
-    tslib "^2.3.1"
-    widest-line "^3.1.0"
-    wrap-ansi "^7.0.0"
-
-"@oclif/linewrap@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz"
-  integrity sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
-
-"@oclif/screen@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.2.tgz#969054308fe98d130c02844a45cc792199b75670"
-  integrity sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ==
-
 "@pmmmwh/react-refresh-webpack-plugin@0.5.4":
   version "0.5.4"
   resolved "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.4.tgz"
@@ -1134,20 +1120,20 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
-"@roots/bud-api@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-api/-/bud-api-5.3.2.tgz#3b84d54b1d1e49d535d26c6195e3d443303dd277"
-  integrity sha512-2ZnY2ojNb+TpPG1QGbgYzKhlMNvtJWsQdR3Qqbj3tdOPpCuCWqZ18kL2m8Kz559Pb5LSCMz9PhHUExB647oHDA==
+"@roots/bud-api@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-api/-/bud-api-5.4.0.tgz#4ffb232369e11a1da4d71f541fd8e7635be66024"
+  integrity sha512-kIrACpVXyCk5xf3NF31wNd23PjT+Elt6ojUdvEqfTf3AL0Teib12e6c5Yyi/m+V4QeAbRU47uUpJ3kWsJSBVNw==
   dependencies:
-    "@roots/bud-support" "5.3.2"
+    "@roots/bud-support" "5.4.0"
     copy-webpack-plugin "10.2.4"
     css-minimizer-webpack-plugin "3.4.1"
     tslib "^2.3.1"
 
-"@roots/bud-babel@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-babel/-/bud-babel-5.3.2.tgz#498db4fbf643beb0e5824ca9f7e5da308bde7b56"
-  integrity sha512-nlxdCmD8swOBcPbxMUK8dsCYVAgF8H01IsW2CFRrKKYpV8Z/fwzCEi7y6/LUqAhRwn87vXKq9Z7HCMYMl6a7hg==
+"@roots/bud-babel@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-babel/-/bud-babel-5.4.0.tgz#06ae30564b4363a89719eb7f0921708d72765e30"
+  integrity sha512-lpidegbJ6xKGQy9bA5r9wZ/MEJSkIxQlHzlsRNBuTRf1OOzgb6aRJq6MYp2MBbcwlViBHq42WMZLV+/hHAJXsw==
   dependencies:
     "@babel/core" "^7.16.0"
     "@babel/plugin-proposal-class-properties" "^7.16.0"
@@ -1159,13 +1145,13 @@
     babel-plugin-add-module-exports "^1.0.4"
     tslib "^2.3.1"
 
-"@roots/bud-build@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-build/-/bud-build-5.3.2.tgz#b215509a02f418c3841bb3334377425f28292387"
-  integrity sha512-lCdLbCBpnbE9ITlGeZny3U8MUJWh4lzCeBd+iFjmd3aPCBfpX5W5Hd+GzEZUbU5jZ4GzJEeb3DYsTOPbVY+qrQ==
+"@roots/bud-build@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-build/-/bud-build-5.4.0.tgz#beff691d331052fdbcaf4a314f0ca11f282fe460"
+  integrity sha512-jkaCzZJs8JqUwlrh8IZVj2YuIqUay2t9jS1SV0cWRPCSe/7XF+WbezD0C8UDIZJXkK5SZzdM3fCn+5j/0q5/4Q==
   dependencies:
-    "@roots/bud-framework" "5.3.2"
-    "@roots/bud-support" "5.3.2"
+    "@roots/bud-framework" "5.4.0"
+    "@roots/bud-support" "5.4.0"
     autobind-decorator "^2.4.0"
     css-loader "^6.5.1"
     csv-loader "^3.0.3"
@@ -1185,67 +1171,67 @@
     url-loader "^4.1.1"
     xml-loader "^1.2.1"
 
-"@roots/bud-cache@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-cache/-/bud-cache-5.3.2.tgz#17730b6a2ef9ff374fa3e99384bb633d9d48d6c2"
-  integrity sha512-kOKlpgLYk9TSHwekxMbuvhI7Pai5GTzPJFBA6BQt+jYAXLWl/2tebRwHWzt/nxPmHcAN6zeP0tRYea39ciaA5g==
+"@roots/bud-cache@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-cache/-/bud-cache-5.4.0.tgz#dfa7d46f6784e0728fb48c2e36d2af480d66dcc0"
+  integrity sha512-S7Euka7RDNpu/fki3+hCU4qQWFITfOJo1kD8Cz4qtJPChfmwAW2KuF/dtM1UE0wtbNmFyJp2ixEK+4zm5wTk0A==
   dependencies:
-    "@roots/bud-support" "5.3.2"
+    "@roots/bud-support" "5.4.0"
     tslib "^2.3.1"
 
-"@roots/bud-compiler@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-compiler/-/bud-compiler-5.3.2.tgz#11ba48a0219a7b491047bc8f834073d64a82260d"
-  integrity sha512-N7Mq4ldSemWg+zn9WpsWYP2aq4Z0BvlgMm6zs9RaOCBe76ILcHO9rs5N3UOxJMVOLrwDoRIFs7s0FcTSG50mHA==
+"@roots/bud-compiler@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-compiler/-/bud-compiler-5.4.0.tgz#c11bad6801f6e75ff14188e3ab4c7ad5213b904a"
+  integrity sha512-R9j2DcLEZKwIm6dbnGcQ382QVENrn2ik/lVzWY4QADuwtNRZPcwMfdRNgMkvVpOjL03gCs7F9It/00sSgCgnHA==
   dependencies:
-    "@roots/bud-support" "^5.3.2"
+    "@roots/bud-support" "^5.4.0"
     helpful-decorators "^2.1.0"
     tslib "^2.3.1"
     webpack "5.68.0"
 
-"@roots/bud-dashboard@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-dashboard/-/bud-dashboard-5.3.2.tgz#f34dd53a1569cf22f44e5281d863f8838bcadc9e"
-  integrity sha512-3vE87ojtnyk8NgmRQs5BiuA7TJSLdnf2cPcI/zCs9JUPRHEfMVx5Y5RRH2QtPHJqTb84Pp+i/B1Bw/bit6H2CA==
+"@roots/bud-dashboard@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-dashboard/-/bud-dashboard-5.4.0.tgz#1347b3b9194d53a83fdd8f65ea6c93529206125d"
+  integrity sha512-ycULNHZUJczEIMXl1+NmSxOYUXaqje3B6K7XUvD6DufVtcQS2Knukv+2rROpl793x6e/xpFAUVD843fpNuCAEw==
   dependencies:
     tslib "^2.3.1"
 
-"@roots/bud-entrypoints@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-entrypoints/-/bud-entrypoints-5.3.2.tgz#6d873183a9973ad6af5bfeda52faa63a010f6d1b"
-  integrity sha512-5Jamaz7lrwPwQSBba5jgYO9ZevG9WCogRJiOy8redQGwNQC0BSWPNylDXloEvMPx+PYaGTKqzqag1a7zkAtbCQ==
+"@roots/bud-entrypoints@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-entrypoints/-/bud-entrypoints-5.4.0.tgz#cd08da97f43f0d51f6aa6fe27dc3aa458ed3f513"
+  integrity sha512-ZsdTK3fcFIRG1nvhqSMvqA69HvCIk+dQEAg4TwsC7GmjKT9Z94FLAIXWBdiKkV9TyjAKp7Go4Ftu4MhJlypSYQ==
   dependencies:
-    "@roots/entrypoints-webpack-plugin" "5.3.2"
+    "@roots/entrypoints-webpack-plugin" "5.4.0"
     autobind-decorator "^2.4.0"
     tslib "^2.3.1"
 
-"@roots/bud-eslint@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-eslint/-/bud-eslint-5.3.2.tgz#df11c678919e4c69499c8b7dfb9401f9311a7dda"
-  integrity sha512-KBuKi5fAx8YcceVcjTsaQCBOg6LE7ogLyOlgfsOdTRVTAftuz6xKPIqQgxr57v62yhg/HhQYQaaPLJ2mOP6Leg==
+"@roots/bud-eslint@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-eslint/-/bud-eslint-5.4.0.tgz#204d6ef7d7ae3ef1a7051875bf5893c5168fb5cd"
+  integrity sha512-SFnYJJYmp+BwUN+AA1ccplTsHZLTb4T4mTtSWCsoXif5HtlkepuU2+qnnnEdKwp7YINe1K16/ng74gIQiCwoNQ==
   dependencies:
     "@babel/eslint-parser" "^7.16.5"
-    eslint "8.8.0"
+    eslint "8.9.0"
     eslint-plugin-import "^2.25.3"
     eslint-webpack-plugin "^3.1.1"
     tslib "^2.3.1"
 
-"@roots/bud-extensions@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-extensions/-/bud-extensions-5.3.2.tgz#fe8190c640a9750aedc18ba3aada0e1dfa8cc23a"
-  integrity sha512-dgLP5syOpGhEGhtSPahFds3C6TOfdT/+6ahEIdphtbC2fcLzD+Qx3OpFPHClPTGw0C6qThd72wnQEGG3PTs9sw==
+"@roots/bud-extensions@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-extensions/-/bud-extensions-5.4.0.tgz#5872b8aac6b69f01f2bda8897d5cde4c553fd15a"
+  integrity sha512-AVbdIu4jKFrRncIZ4V8uEgjPS+Uu9NlXrSho3nPzozdxuC/flGhnyeGUEJH3A3xH0o6V563sNu94A6cxNf3RAA==
   dependencies:
-    "@roots/bud-support" "5.3.2"
+    "@roots/bud-support" "5.4.0"
     autobind-decorator "^2.4.0"
     tslib "^2.3.1"
 
-"@roots/bud-framework@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-framework/-/bud-framework-5.3.2.tgz#22db6a3008b3a35ed1296913352d90903374eebd"
-  integrity sha512-xNcJBkt32qe9S39GCvtwOCjnBYZC3hq6wDj8wRdB/HHllu37I0PWFhhWw9tCL3U3bCexYgl1ilWJwDIP71sx7w==
+"@roots/bud-framework@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-framework/-/bud-framework-5.4.0.tgz#a7ae2e0f22815d151d31912e30ca5a6339fa0cfd"
+  integrity sha512-yYOWPuuQkoGHa5xqpnuaS3gsukhQmvhJa2aB22wkOtVWX2/IofRJ1ZTDGARAM9SRsf5f/dbbX29oICyBjsMr9A==
   dependencies:
-    "@roots/bud-support" "5.3.2"
-    "@roots/container" "5.3.2"
+    "@roots/bud-support" "5.4.0"
+    "@roots/container" "5.4.0"
     cli-highlight "^2.1.11"
     js-yaml "^4.1.0"
     json5 "^2.2.0"
@@ -1253,61 +1239,60 @@
     ts-node "^10.4.0"
     tslib "^2.3.1"
 
-"@roots/bud-hooks@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-hooks/-/bud-hooks-5.3.2.tgz#177a97941d13e938a863ed9c96213b9560b12263"
-  integrity sha512-nQkQ/jboEIGggWHszT8VIDfttjWvuWYP6KWgSl72vZup746G4/MZ88obqEKA+uqXfm57zMpOxzApkWw7LWr88Q==
+"@roots/bud-hooks@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-hooks/-/bud-hooks-5.4.0.tgz#ada79fc00ee29b83bd6846d4638de94047d9c6cc"
+  integrity sha512-w3HgDwtd+V0xjAsRFBS4fWaR+ANVjlFMGFAGvFFKI9BSUY1Ve5+xK18gIziVxmbj+c2pCP3YIOYllj6NWd6Gqw==
   dependencies:
-    "@roots/bud-framework" "5.3.2"
-    "@roots/bud-support" "5.3.2"
+    "@roots/bud-framework" "5.4.0"
+    "@roots/bud-support" "5.4.0"
     autobind-decorator "^2.4.0"
     lodash "^4.17.21"
     pretty-format "^27.3.1"
     tslib "^2.3.1"
 
-"@roots/bud-postcss@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-postcss/-/bud-postcss-5.3.2.tgz#e8692d136e4f0cfd244f39a2ef0006230c1a3024"
-  integrity sha512-FlFFS50t+LPzDIC43r4okX3QD8otJ39oVYummYhI7Lsxhzt351EerzEWIUylR/WOEs3iayibl3DUsuHMzp4G/g==
+"@roots/bud-postcss@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-postcss/-/bud-postcss-5.4.0.tgz#5cb68e85f44754dee251982e88c032db758cefa4"
+  integrity sha512-hwIpkaYqewFxpoYQAsT4/dbnqLnhST8MBjcDskkI2cwpLcxfKyI+izySRkRm9Umjh3Vac6+YccUECVqdgFbYGQ==
   dependencies:
-    "@roots/bud-build" "5.3.2"
+    "@roots/bud-build" "5.4.0"
     postcss "8.4.6"
     postcss-import "14.0.2"
     postcss-loader "6.2.1"
     postcss-nested "5.0.6"
-    postcss-preset-env "7.3.1"
+    postcss-preset-env "7.4.1"
     tslib "2.3.1"
 
-"@roots/bud-preset-recommend@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-preset-recommend/-/bud-preset-recommend-5.3.2.tgz#8ea9306ee6a550dfb123f2f2deb8f331a1283001"
-  integrity sha512-lZjosS3cDQGVLE6nAq+Jw5LJaOwk88GhzykFYvjsvCk09zcxcjmlwWse8leIQWqyMq6hhf6hg+CYTl9QCzoAUw==
+"@roots/bud-preset-recommend@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-preset-recommend/-/bud-preset-recommend-5.4.0.tgz#e6fdf61a15b02da17380de7f8c4dd57f908f6a43"
+  integrity sha512-PMmN2g9MJw9Rd3oKfnEV3wtP3ILvqsMJUUUDrCroUfgmJ7qQ1KE91nvruA/A6HHalXyGK38qoqCHNR0Aisb+NA==
   dependencies:
-    "@roots/bud-babel" "5.3.2"
-    "@roots/bud-entrypoints" "5.3.2"
-    "@roots/bud-eslint" "5.3.2"
-    "@roots/bud-postcss" "5.3.2"
+    "@roots/bud-babel" "5.4.0"
+    "@roots/bud-entrypoints" "5.4.0"
+    "@roots/bud-postcss" "5.4.0"
     tslib "2.3.1"
 
-"@roots/bud-preset-wordpress@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-preset-wordpress/-/bud-preset-wordpress-5.3.2.tgz#c23a07a4f2f0c103f44235a883e55a2c4fdb9302"
-  integrity sha512-QK4iIcKkraQQxNAtESuAbs7GOyBtuklUyQeSFI5XJ1F2Aritf2T5yo9SMf1oAvMZAvqqlZEqSPHDKNXGORzDrg==
+"@roots/bud-preset-wordpress@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-preset-wordpress/-/bud-preset-wordpress-5.4.0.tgz#648072d5500d977b8da486aeea83b932763037b8"
+  integrity sha512-yQ/j4dYlW8K+lEOvmw74Vvi2VKNmp0VgFpa12/m7A5nraIos9IAL7Tp+/Gg9LHJBFyfPt/g/G7hFbGklgbmt5Q==
   dependencies:
-    "@roots/bud-babel" "5.3.2"
-    "@roots/bud-entrypoints" "5.3.2"
-    "@roots/bud-preset-recommend" "5.3.2"
-    "@roots/bud-react" "5.3.2"
-    "@roots/bud-wordpress-dependencies" "5.3.2"
-    "@roots/bud-wordpress-externals" "5.3.2"
-    "@roots/bud-wordpress-manifests" "5.3.2"
-    "@wordpress/browserslist-config" "4.1.0"
+    "@roots/bud-babel" "5.4.0"
+    "@roots/bud-entrypoints" "5.4.0"
+    "@roots/bud-preset-recommend" "5.4.0"
+    "@roots/bud-react" "5.4.0"
+    "@roots/bud-wordpress-dependencies" "5.4.0"
+    "@roots/bud-wordpress-externals" "5.4.0"
+    "@roots/bud-wordpress-manifests" "5.4.0"
+    "@wordpress/browserslist-config" "4.1.1"
     tslib "2.3.1"
 
-"@roots/bud-prettier@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-prettier/-/bud-prettier-5.3.2.tgz#8a96035611705a87d208f178ec784515846ac064"
-  integrity sha512-b1EvqwHEPwMw3VSf2GcWVqSIR+jC+CXpi0LMkVf4ggePlQEN4bXxbE3z5iWHcIUG3WiAtgPuVbXlgl+z3kAVbg==
+"@roots/bud-prettier@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-prettier/-/bud-prettier-5.4.0.tgz#7ee6688874e5f1debebbff5f4d0d51b91c6be751"
+  integrity sha512-0LB14QNzR2SWtUl/RMrlt+6l37PicFgG+5Yx/YIKACIA3ZkLXs3a4oci12jSwi0ZRV5j6jdZwNzmYuF2RcPp4g==
   dependencies:
     autobind-decorator "2.4.0"
     eslint-config-prettier "^8.3.0"
@@ -1315,10 +1300,10 @@
     prettier "2.5.1"
     tslib "2.3.1"
 
-"@roots/bud-react@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-react/-/bud-react-5.3.2.tgz#f9c633fcd209e1c6e42d1b0b6a890aaa24aaed2a"
-  integrity sha512-AbaBU1lGrccVQvu++ql6P6kKjDZl+CmPw9EIU3Q2XNak9Ws4IQehG3UWrPfZfKPs8QAYfto1UH8aTqli0b70Wg==
+"@roots/bud-react@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-react/-/bud-react-5.4.0.tgz#fb11005cb2d6248f716735d6a09f62c010d95631"
+  integrity sha512-+Le8fy9AOdbthQuv+zvx/6hqrPQNzAxjQZAULNUFDSGwUuEOv6SfXroUxmx5WrxREnjyGXIAcP/2gXJyMGLGgw==
   dependencies:
     "@babel/plugin-syntax-jsx" "^7.16.0"
     "@babel/preset-react" "^7.16.0"
@@ -1333,26 +1318,25 @@
     react-refresh "^0.11.0"
     tslib "2.3.1"
 
-"@roots/bud-server@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-server/-/bud-server-5.3.2.tgz#ecd6f786fa7d05bcdffae4e663bf6f046c3c1913"
-  integrity sha512-J54yjapTTP2Qs2yd+KgopTwjNL/SlmHYExuxvVfP6jbwjkiR6+9N8a+haur1IO4C4DIYxHFa4uSAf3jLj661sA==
+"@roots/bud-server@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-server/-/bud-server-5.4.0.tgz#f2deef58a9e52119acecf517a8de78eaa6a5eb84"
+  integrity sha512-/jtYVD7vt4/hX87QkgZBFVFc64y5P2HONd5tVB490ccKFt+2hZ1bubuBoR6uRn0ptT0u+Akgd1Kw+PD+c79Yjw==
   dependencies:
-    "@roots/bud-framework" "5.3.2"
-    "@roots/bud-support" "5.3.2"
-    "@roots/container" "5.3.2"
+    "@roots/bud-framework" "5.4.0"
+    "@roots/bud-support" "5.4.0"
+    "@roots/container" "5.4.0"
     chokidar "^3.5.2"
     express "^4.17.1"
-    globby "^11.0.0"
     http-proxy-middleware "2.0.3"
     tslib "^2.3.1"
     webpack-dev-middleware "5.3.1"
     webpack-hot-middleware "^2.25.1"
 
-"@roots/bud-stylelint@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-stylelint/-/bud-stylelint-5.3.2.tgz#e9aa18526f984266c69cd3f7a25ea03a21538c07"
-  integrity sha512-Y7o86Xy9PZeD9yQ2Qq4TJDdKcvUCRa0bWJ3fIqrg/9QvM/yg64mXqgV9ZL4wzt7Wf8EV/H/ybpm29y6zP+LMjw==
+"@roots/bud-stylelint@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-stylelint/-/bud-stylelint-5.4.0.tgz#28a072f73cbc4bd2c8737ee468a1409e7a184f0c"
+  integrity sha512-ybfZtDk4pJp1MmKOr81dV4BgmEzRR9xyQ7tKSelkrtvWJfOzt3Rp6QpwDPjmBA/oE8GRGalBowvl0ZyBqWetAA==
   dependencies:
     autobind-decorator "^2.4.0"
     stylelint "^14.5.0"
@@ -1360,136 +1344,148 @@
     stylelint-webpack-plugin "^3.1.1"
     tslib "^2.3.1"
 
-"@roots/bud-support@5.3.2", "@roots/bud-support@^5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-support/-/bud-support-5.3.2.tgz#c716121f316bfea39fb50479d7d9812e81213a83"
-  integrity sha512-wdzUQvNOrOHuEoOdkdyJ2V5UB1W0WoKIlzzzJPJrxEnExwApYts8jiGsRokLvc3FC8aj32o3ODfxO3rHc9e3Bg==
+"@roots/bud-support@5.4.0", "@roots/bud-support@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-support/-/bud-support-5.4.0.tgz#564e123b73a266f85b939c42b8a8f913cf0480b6"
+  integrity sha512-HUVtdT21tIQD6P3pKUXKi452+iofF0awdHTBvMQtvRNBJvBCsS8cVxk41jbKijrUDYkV/5k9d5AFEJLrjg9RlA==
 
-"@roots/bud-tailwindcss@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-tailwindcss/-/bud-tailwindcss-5.3.2.tgz#ea9e8f8740fe12ddc2e40ca95a80c9ac138269ee"
-  integrity sha512-eNwkc7zkg2zzk0bCDE8OJ9JYmAlCSLvKNB3uubNK+za/I8fhZHJskXh3UVy56NYZtdXiL+kji0dP7Qm7A+NyBg==
+"@roots/bud-tailwindcss@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-tailwindcss/-/bud-tailwindcss-5.4.0.tgz#1aa9160de8af96d50853151730c584eaa0edcca3"
+  integrity sha512-kYwZTpH4+93ldVhnK3FUtIPHsEY26TAnG3svS2TnENb7dJZRL8rRvgDGU/4Skx+z/1qt8Ps4pa1Yh1/FUNRarw==
   dependencies:
     autoprefixer "^10.4.0"
-    tailwindcss "3.0.19"
+    tailwindcss "3.0.23"
     tslib "^2.3.1"
 
-"@roots/bud-wordpress-dependencies@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-wordpress-dependencies/-/bud-wordpress-dependencies-5.3.2.tgz#f7c8371343e88f1c0d07032a96f1fca3096513e6"
-  integrity sha512-85xkbYVU3d92J1096GZUMjQGjFCVel7Nvmt4bTGlRgNxZYzFi+umVCidE/yKnCYLfMSmUzdNG6sxc2ATgJVu1Q==
+"@roots/bud-wordpress-dependencies@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-wordpress-dependencies/-/bud-wordpress-dependencies-5.4.0.tgz#e85c3950a02d4171021f108528cc26b2b805fe82"
+  integrity sha512-b9DqLEsEAW6kBTeEkhuHl6jHGEpKTUbRsqA9CobIiex/I308A1Ghlf4RhTaWlmf4BEU1Eki8m+3/draBmAxEeA==
   dependencies:
-    "@roots/wordpress-dependencies-webpack-plugin" "5.3.2"
+    "@roots/wordpress-dependencies-webpack-plugin" "5.4.0"
     autobind-decorator "^2.4.0"
     lodash "^4.17.21"
     tslib "^2.3.1"
 
-"@roots/bud-wordpress-externals@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-wordpress-externals/-/bud-wordpress-externals-5.3.2.tgz#f089dfd32830bf769d7f2f064971108979209253"
-  integrity sha512-TNyF6lsPbLJaKzWf4oRIzfcG5s4GaAaku27Gco0/KgWo8/o9NolK3IJgeU2jx8M1Qlo7USxkagf8q2DzMMJlSQ==
+"@roots/bud-wordpress-externals@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-wordpress-externals/-/bud-wordpress-externals-5.4.0.tgz#1b22d7c496ee1804f00045fbd99f4c8c8612f228"
+  integrity sha512-0Mbb/VA4iOkKSuqNq8q7lZv78WOiOjI/01X5iXGW4QiKYaXFi4p+DTeXHkYTAAjj7+N4QOny35WAZ/Wj/Liwzg==
   dependencies:
-    "@roots/wordpress-externals-webpack-plugin" "5.3.2"
+    "@roots/wordpress-externals-webpack-plugin" "5.4.0"
     autobind-decorator "^2.4.0"
     tslib "^2.3.1"
 
-"@roots/bud-wordpress-manifests@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud-wordpress-manifests/-/bud-wordpress-manifests-5.3.2.tgz#aa3967143b1f6708e8df75745b41efbed23665f5"
-  integrity sha512-c8xeJxTQK+5LdMm8ZIOyTM6dWOA7782swZhSdkBL0p/jFILBq5MgQ3mNpBC8viQzRAMVyrddnWYb3r5hgT56iA==
+"@roots/bud-wordpress-manifests@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud-wordpress-manifests/-/bud-wordpress-manifests-5.4.0.tgz#9c561b09b91eddd7b731dae5ebf74422e898999b"
+  integrity sha512-xNY5xgx8uMbo6kUDJH9LnFU4dtqKbk2bEQXjN5WLOGDxrZlDUEW76z/uP1gNklQoUFLWCxe05AaQsknNK3FAQg==
   dependencies:
-    "@roots/merged-manifest-webpack-plugin" "5.3.2"
+    "@roots/merged-manifest-webpack-plugin" "5.4.0"
     autobind-decorator "^2.4.0"
     tslib "^2.3.1"
 
-"@roots/bud@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/bud/-/bud-5.3.2.tgz#2ff9a8a9c612e5d0a3ff93d7a8938677547b789b"
-  integrity sha512-glHQrdEAlDzr3Idg4eRia+GIJnlj6gvrLo21eVHyTawpagjzLD0VNL5NfcZcnEM2T5St8F96QqfZYqsPOIQdXA==
+"@roots/bud@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/bud/-/bud-5.4.0.tgz#c20bb4b52d22c761f2ae154415b41ba98ff3bb22"
+  integrity sha512-mr3n2jPIDrAJLchNQfIpb6H1gm1l8cf3ePoJpIKQdmYtOiQtAHu1RR2Zv1v06FFVN59LkEAG1vBmv0DGgMdmxA==
   dependencies:
-    "@oclif/core" "1.3.3"
-    "@roots/bud-api" "5.3.2"
-    "@roots/bud-build" "5.3.2"
-    "@roots/bud-cache" "5.3.2"
-    "@roots/bud-compiler" "5.3.2"
-    "@roots/bud-dashboard" "5.3.2"
-    "@roots/bud-extensions" "5.3.2"
-    "@roots/bud-framework" "5.3.2"
-    "@roots/bud-hooks" "5.3.2"
-    "@roots/bud-server" "5.3.2"
-    "@roots/bud-support" "5.3.2"
-    "@roots/container" "5.3.2"
-    "@roots/dependencies" "5.3.2"
-    braces "3.0.2"
+    "@roots/bud-api" "5.4.0"
+    "@roots/bud-build" "5.4.0"
+    "@roots/bud-cache" "5.4.0"
+    "@roots/bud-compiler" "5.4.0"
+    "@roots/bud-dashboard" "5.4.0"
+    "@roots/bud-extensions" "5.4.0"
+    "@roots/bud-framework" "5.4.0"
+    "@roots/bud-hooks" "5.4.0"
+    "@roots/bud-server" "5.4.0"
+    "@roots/bud-support" "5.4.0"
+    "@roots/container" "5.4.0"
+    "@roots/dependencies" "5.4.0"
     clean-webpack-plugin "^4.0.0"
+    clipanion "3.2.0-rc.9"
     copy-webpack-plugin "^10.0.0"
-    execa "5.1.1"
-    fast-glob "3.2.11"
     fs-extra "^10.0.0"
-    globby "^11.0.0"
     helpful-decorators "^2.1.0"
     html-webpack-plugin "^5.5.0"
     lodash "^4.17.21"
     mini-css-extract-plugin "^2.4.5"
     tslib "^2.3.1"
+    typanion "3.7.1"
     type-fest "^2.5.4"
     webpack "5.68.0"
     webpack-cli "^4.9.1"
     webpack-manifest-plugin "^4.0.2"
 
-"@roots/container@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/container/-/container-5.3.2.tgz#5ba07c4ee2c92331796b7b87501b1cf9758d0cc5"
-  integrity sha512-5jc+EsEpI/DAwzrLQhw+x4jG7iqQt+//qJ8DeTc9/J83sDcqu1+XIZV+h7JZ4QEOgG/+r2rtnkAWwT6lFs8XQA==
+"@roots/container@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/container/-/container-5.4.0.tgz#df095da20cc3f08e614a0dd67ef2237d8f620c6f"
+  integrity sha512-tnj9KAgoBiXqjT2eJMUNyvHqBc1DSJPxB7iOvQ9Ss4MPcpYJRB6KoUvbRKBywU0zd9htETaXxW+4bDJATD+eBg==
   dependencies:
     tslib "^2.3.1"
 
-"@roots/dependencies@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/dependencies/-/dependencies-5.3.2.tgz#12e5a120a09126c148de44a4a1f64d9ce6ff3de6"
-  integrity sha512-us3P7o44ntth1mzG3U6Evb/UGWuZn6Gukqgx7vGHs2gBBjUYyzp10EtryfzYdj7iB5bMTcYoAK8Vao3W4H5vSg==
+"@roots/dependencies@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/dependencies/-/dependencies-5.4.0.tgz#96534cb6bc1691d862c1ff61ead8201c1dd1e3ac"
+  integrity sha512-DPdm2J9edvLN//pTQBzCKVcodxPjp/SwWUkiBe8aCUghfZz/IsGrNRH+al+Ba6III/cyArrotOyichZwMiN3gQ==
   dependencies:
     autobind-decorator "^2.4.0"
     helpful-decorators "^2.1.0"
     tslib "^2.3.1"
 
-"@roots/entrypoints-webpack-plugin@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/entrypoints-webpack-plugin/-/entrypoints-webpack-plugin-5.3.2.tgz#909b21d5afb7068de18bd898d7f08ca93f50c5b2"
-  integrity sha512-1aVdontSBhp4FG/Loi1yqH901/ofXErQgDXcKt/bc5B6FQH8a0WLr+lRTZWNAQcZAN81CaZcf9jtB/XoILaLJA==
+"@roots/entrypoints-webpack-plugin@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/entrypoints-webpack-plugin/-/entrypoints-webpack-plugin-5.4.0.tgz#7ce226fc85f1f67580d923aed1cef6dd770076ec"
+  integrity sha512-nubEf/6huCV9GPW6ECAEjz/eP/XfEM9HbAHJeRCyjybCxO8Ak/MtGM36eoNhG/LJcuRWMHHxlQT/yolAvfEIzw==
   dependencies:
     tslib "^2.3.1"
 
-"@roots/merged-manifest-webpack-plugin@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/merged-manifest-webpack-plugin/-/merged-manifest-webpack-plugin-5.3.2.tgz#210b1915adae6529b97d688282bc41733c34470c"
-  integrity sha512-/JrcIJ2yrMnbqcWaXrz/WtbatD7SK/mTCEN+NbZqPi2sCI72gHVE69Gs/UcsJu7sBTfy2MqZfPtzOOB32oHadg==
+"@roots/eslint-config@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/eslint-config/-/eslint-config-5.4.0.tgz#7fc005cca2cf7429e4b6170a70d94c4859220953"
+  integrity sha512-hoVErOnu3Hc1cPaS/AmOMVmsVvhMg4U12YE+zelvylO+QwJhYWRndtvLSP66kkbbZx3VnDGe7/qjIlWzxzQ5/g==
+  dependencies:
+    "@babel/eslint-parser" "^7.16.5"
+    "@typescript-eslint/eslint-plugin" "^5.10.1"
+    "@typescript-eslint/parser" "5.12.0"
+    eslint "^7.32.0 || ^8.2.0"
+    eslint-plugin-import "^2.25.3"
+    eslint-plugin-jsx-a11y "^6.5.1"
+    eslint-plugin-react "^7.27.1"
+    eslint-plugin-react-hooks "^4.3.0"
+
+"@roots/merged-manifest-webpack-plugin@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/merged-manifest-webpack-plugin/-/merged-manifest-webpack-plugin-5.4.0.tgz#370729b2b5031df2cda396a91229f6b6eeb7e586"
+  integrity sha512-zLx/FhAde7V6hQYHGJqwZCvgsd1PetA/0I8be7SLwFbcfsvn/7rilNsyiaZmViGOCiw0CI3G5GlaLe8MaRxKdA==
   dependencies:
     fs-extra "^10.0.0"
     helpful-decorators "^2.1.0"
     tslib "^2.3.1"
 
-"@roots/sage@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/sage/-/sage-5.3.2.tgz#d4ef3739ef36806611ef278c372908ef3be2d6b3"
-  integrity sha512-YUUods0cZGNN6UfbM1ETFsHG7uB1X+vIBs1Ekw9VNhsMBAMJl7lUeSwHVEwtAaEQqxfcPmBR6x2loTbF1+VVFQ==
+"@roots/sage@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/sage/-/sage-5.4.0.tgz#f1582a141e6d426f2a94eda0ed4c4355b3a5470b"
+  integrity sha512-5OUwoJvhMX1JZTHRMgrJksA0P1FifB5Sex6iYXRVeUpdI+bocXLqP+U/gmqf4ZmtsyUwKAtbp2Lr3F3k1BZSyQ==
   dependencies:
-    "@roots/bud-preset-wordpress" "5.3.2"
-    "@roots/bud-support" "5.3.2"
+    "@roots/bud-eslint" "5.4.0"
+    "@roots/bud-preset-wordpress" "5.4.0"
+    "@roots/bud-support" "5.4.0"
     helpful-decorators "^2.1.0"
     tslib "^2.3.1"
 
-"@roots/wordpress-dependencies-webpack-plugin@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/wordpress-dependencies-webpack-plugin/-/wordpress-dependencies-webpack-plugin-5.3.2.tgz#2183cba2970fa639d8cb6018b21afdeac161dfd1"
-  integrity sha512-UVDk44X47LLuKZwd5jqlDL5znOss9xuvOFVkpvtj7IwuGi+FKIlApe1I7JxpCcpW3PPvAjTF74BcKGQueb2tDQ==
+"@roots/wordpress-dependencies-webpack-plugin@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/wordpress-dependencies-webpack-plugin/-/wordpress-dependencies-webpack-plugin-5.4.0.tgz#a9d352f28939d8792a126dc7ecb1375926b9cbed"
+  integrity sha512-qx1AYSf5fNnzZmLnCz+Spty1fM67oEpX99aENEBb0hQfhpisdzTfDM/Rfv92F8BI8mQEtMJOD3OqyYd7gyd6Bg==
   dependencies:
     tslib "^2.3.1"
 
-"@roots/wordpress-externals-webpack-plugin@5.3.2":
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/@roots/wordpress-externals-webpack-plugin/-/wordpress-externals-webpack-plugin-5.3.2.tgz#d499d9cc922e14945f618d20448ce4857bdc7c2a"
-  integrity sha512-C636ki5NjIWJRTcoLDNqSG35GRK+nm2KDTMYl9b7u5uap/B2vZWlo7PKwETpj86CmlLuKL9rzILz2iH0SAcVZA==
+"@roots/wordpress-externals-webpack-plugin@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/@roots/wordpress-externals-webpack-plugin/-/wordpress-externals-webpack-plugin-5.4.0.tgz#3fc82097c9e094ceee2690f3ce65c827d2dfcb65"
+  integrity sha512-bVbJg5JJRgVSmIu4vACpxE1jwJlhmTABNh4YHSedpXJ2ga/ubhsRaTBTYJB1sRkaWLFJrQRGeoDMUODZJwIXUw==
   dependencies:
     tslib "^2.3.1"
 
@@ -1661,6 +1657,120 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@typescript-eslint/eslint-plugin@^5.10.1":
+  version "5.12.1"
+  resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.12.1.tgz#b2cd3e288f250ce8332d5035a2ff65aba3374ac4"
+  integrity sha512-M499lqa8rnNK7mUv74lSFFttuUsubIRdAbHcVaP93oFcKkEmHmLqy2n7jM9C8DVmFMYK61ExrZU6dLYhQZmUpw==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.12.1"
+    "@typescript-eslint/type-utils" "5.12.1"
+    "@typescript-eslint/utils" "5.12.1"
+    debug "^4.3.2"
+    functional-red-black-tree "^1.0.1"
+    ignore "^5.1.8"
+    regexpp "^3.2.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/parser@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.12.0.tgz#0ca669861813df99ce54916f66f524c625ed2434"
+  integrity sha512-MfSwg9JMBojMUoGjUmX+D2stoQj1CBYTCP0qnnVtu9A+YQXVKNtLjasYh+jozOcrb/wau8TCfWOkQTiOAruBog==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.12.0"
+    "@typescript-eslint/types" "5.12.0"
+    "@typescript-eslint/typescript-estree" "5.12.0"
+    debug "^4.3.2"
+
+"@typescript-eslint/scope-manager@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.0.tgz#59619e6e5e2b1ce6cb3948b56014d3a24da83f5e"
+  integrity sha512-GAMobtIJI8FGf1sLlUWNUm2IOkIjvn7laFWyRx7CLrv6nLBI7su+B7lbStqVlK5NdLvHRFiJo2HhiDF7Ki01WQ==
+  dependencies:
+    "@typescript-eslint/types" "5.12.0"
+    "@typescript-eslint/visitor-keys" "5.12.0"
+
+"@typescript-eslint/scope-manager@5.12.1":
+  version "5.12.1"
+  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.1.tgz#58734fd45d2d1dec49641aacc075fba5f0968817"
+  integrity sha512-J0Wrh5xS6XNkd4TkOosxdpObzlYfXjAFIm9QxYLCPOcHVv1FyyFCPom66uIh8uBr0sZCrtS+n19tzufhwab8ZQ==
+  dependencies:
+    "@typescript-eslint/types" "5.12.1"
+    "@typescript-eslint/visitor-keys" "5.12.1"
+
+"@typescript-eslint/type-utils@5.12.1":
+  version "5.12.1"
+  resolved "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.12.1.tgz#8d58c6a0bb176b5e9a91581cda1a7f91a114d3f0"
+  integrity sha512-Gh8feEhsNLeCz6aYqynh61Vsdy+tiNNkQtc+bN3IvQvRqHkXGUhYkUi+ePKzP0Mb42se7FDb+y2SypTbpbR/Sg==
+  dependencies:
+    "@typescript-eslint/utils" "5.12.1"
+    debug "^4.3.2"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/types@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.0.tgz#5b4030a28222ee01e851836562c07769eecda0b8"
+  integrity sha512-JowqbwPf93nvf8fZn5XrPGFBdIK8+yx5UEGs2QFAYFI8IWYfrzz+6zqlurGr2ctShMaJxqwsqmra3WXWjH1nRQ==
+
+"@typescript-eslint/types@5.12.1":
+  version "5.12.1"
+  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.1.tgz#46a36a28ff4d946821b58fe5a73c81dc2e12aa89"
+  integrity sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==
+
+"@typescript-eslint/typescript-estree@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.0.tgz#cabf545fd592722f0e2b4104711e63bf89525cd2"
+  integrity sha512-Dd9gVeOqt38QHR0BEA8oRaT65WYqPYbIc5tRFQPkfLquVEFPD1HAtbZT98TLBkEcCkvwDYOAvuSvAD9DnQhMfQ==
+  dependencies:
+    "@typescript-eslint/types" "5.12.0"
+    "@typescript-eslint/visitor-keys" "5.12.0"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.12.1":
+  version "5.12.1"
+  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.1.tgz#6a9425b9c305bcbc38e2d1d9a24c08e15e02b722"
+  integrity sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==
+  dependencies:
+    "@typescript-eslint/types" "5.12.1"
+    "@typescript-eslint/visitor-keys" "5.12.1"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.12.1":
+  version "5.12.1"
+  resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.1.tgz#447c24a05d9c33f9c6c64cb48f251f2371eef920"
+  integrity sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.12.1"
+    "@typescript-eslint/types" "5.12.1"
+    "@typescript-eslint/typescript-estree" "5.12.1"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
+"@typescript-eslint/visitor-keys@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.0.tgz#1ac9352ed140b07ba144ebf371b743fdf537ec16"
+  integrity sha512-cFwTlgnMV6TgezQynx2c/4/tx9Tufbuo9LPzmWqyRC3QC4qTGkAG1C6pBr0/4I10PAI/FlYunI3vJjIcu+ZHMg==
+  dependencies:
+    "@typescript-eslint/types" "5.12.0"
+    eslint-visitor-keys "^3.0.0"
+
+"@typescript-eslint/visitor-keys@5.12.1":
+  version "5.12.1"
+  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz#f722da106c8f9695ae5640574225e45af3e52ec3"
+  integrity sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==
+  dependencies:
+    "@typescript-eslint/types" "5.12.1"
+    eslint-visitor-keys "^3.0.0"
+
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz"
@@ -1799,10 +1909,10 @@
   resolved "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz"
   integrity sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==
 
-"@wordpress/browserslist-config@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-4.1.0.tgz"
-  integrity sha512-RSJhgY2xmz6yAdDNhz/NvAO6JS+91vv9cVL7VDG2CftbyjTXBef05vWt3FzZhfeF0xUrYdpZL1PVpxmJiKvbEg==
+"@wordpress/browserslist-config@4.1.1":
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-4.1.1.tgz#bbee2bc0c43f651e4cdf590e89f36d961f2a3fd9"
+  integrity sha512-fz2IQ3eghmnWIb3YnSSC1aNlrdNPBF53b5RIdF6Zt5Wtk9k3NZ+YmH6ph8zUyktSzckRkV0dNsI3X9Z1RU49gQ==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -1923,18 +2033,6 @@ alphanum-sort@^1.0.2:
   resolved "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
-ansi-escapes@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz"
-  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
-
-ansi-escapes@^4.3.0:
-  version "4.3.2"
-  resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz"
-  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
-  dependencies:
-    type-fest "^0.21.3"
-
 ansi-html-community@0.0.8, ansi-html-community@^0.0.8:
   version "0.0.8"
   resolved "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz"
@@ -1952,7 +2050,7 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.2.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -1963,11 +2061,6 @@ ansi-styles@^5.0.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
-
-ansicolors@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz"
-  integrity sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=
 
 any-promise@^1.0.0:
   version "1.3.0"
@@ -2082,16 +2175,6 @@ astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
-
-async@0.9.x:
-  version "0.9.2"
-  resolved "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
-
-at-least-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz"
-  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 autobind-decorator@2.4.0, autobind-decorator@^2.4.0:
   version "2.4.0"
@@ -2220,7 +2303,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@3.0.2, braces@^3.0.1, braces@~3.0.2:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -2303,20 +2386,12 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001297:
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz"
   integrity sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==
 
-cardinal@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz"
-  integrity sha1-fMEFXYItISlU0HsIXeolHMe8VQU=
-  dependencies:
-    ansicolors "~0.3.2"
-    redeyed "~2.1.0"
-
 ccount@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
 
-chalk@^2.0.0, chalk@^2.3.2, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.3.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2390,13 +2465,6 @@ clean-css@^5.2.2:
   dependencies:
     source-map "~0.6.0"
 
-clean-stack@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz"
-  integrity sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==
-  dependencies:
-    escape-string-regexp "4.0.0"
-
 clean-webpack-plugin@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-4.0.0.tgz"
@@ -2416,12 +2484,12 @@ cli-highlight@^2.1.11:
     parse5-htmlparser2-tree-adapter "^6.0.0"
     yargs "^16.0.0"
 
-cli-progress@^3.10.0:
-  version "3.10.0"
-  resolved "https://registry.npmjs.org/cli-progress/-/cli-progress-3.10.0.tgz"
-  integrity sha512-kLORQrhYCAtUPLZxqsAt2YJGOvRdt34+O6jl5cQGb7iF3dM55FQZlTR+rQyIK9JUcO9bBMwZsTlND+3dmFU2Cw==
+clipanion@3.2.0-rc.9:
+  version "3.2.0-rc.9"
+  resolved "https://registry.npmjs.org/clipanion/-/clipanion-3.2.0-rc.9.tgz#cb2de4829c2f837aa3767216a451273ad34245bc"
+  integrity sha512-YwsXDnsnC1fcotfXC+UyySxJh8AkZbxPCcniP+TagQi5didSuxj+AGDgv6fEf3JI2Yondbr5QcBdwCgk0A15tw==
   dependencies:
-    string-width "^4.2.0"
+    typanion "^3.3.1"
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -2599,17 +2667,6 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-spawn@^6.0.5:
-  version "6.0.5"
-  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz"
-  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
-  dependencies:
-    nice-try "^1.0.4"
-    path-key "^2.0.1"
-    semver "^5.5.0"
-    shebang-command "^1.2.0"
-    which "^1.2.9"
-
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
@@ -2619,7 +2676,7 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-blank-pseudo@^3.0.2:
+css-blank-pseudo@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-3.0.3.tgz#36523b01c12a25d812df343a32c322d2a2324561"
   integrity sha512-VS90XWtsHGqoM0t4KpH053c4ehxZ2E6HtGI7x68YFV0pTo/QmkV/YFA+NnlvK8guxZVNWGQhVNJGC39Q8XF4OQ==
@@ -2638,7 +2695,7 @@ css-functions-list@^3.0.0:
   resolved "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.0.tgz#faa770a0666aea11435efc0889935336cea564be"
   integrity sha512-rfwhBOvXVFcKrSwmLxD8JQyuEEy/3g3Y9FMI2l6iV558Coeo1ucXypXb4rwrVpk5Osh5ViXp2DTgafw8WxglhQ==
 
-css-has-pseudo@^3.0.3:
+css-has-pseudo@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-3.0.4.tgz#57f6be91ca242d5c9020ee3e51bbb5b89fc7af73"
   integrity sha512-Vse0xpR1K9MNlp2j5w1pgWIJtm1a8qS0JwS9goFYcImjlHEmywP9VUF05aGBXzGpDJF86QXk4L0ypBmwPhGArw==
@@ -2700,10 +2757,10 @@ css-what@^5.1.0:
   resolved "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz"
   integrity sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==
 
-cssdb@^6.1.0:
-  version "6.2.1"
-  resolved "https://registry.npmjs.org/cssdb/-/cssdb-6.2.1.tgz#8904c3f8005bfc334009ee20ddb201330d5a5199"
-  integrity sha512-TBIhtDCOeYjwr44Vpl1g/224/18lI0jW+PKdA5ZP30dhre3eEutVUb2mnqUnpRPiPWQB7BQf8CWiUGOa966Fnw==
+cssdb@^6.3.1:
+  version "6.4.0"
+  resolved "https://registry.npmjs.org/cssdb/-/cssdb-6.4.0.tgz#54899b9042e302be3090b8510ea71fefd08c9e6b"
+  integrity sha512-8NMWrur/ewSNrRNZndbtOTXc2Xb2b+NCTPHj8VErFYvJUlgsMAiBGaFaxG6hjy9zbCjj2ZLwSQrMM+tormO8qA==
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -2971,13 +3028,6 @@ ee-first@1.1.1:
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-ejs@^3.1.6:
-  version "3.1.6"
-  resolved "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz"
-  integrity sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==
-  dependencies:
-    jake "^10.6.1"
-
 electron-to-chromium@^1.4.17:
   version "1.4.18"
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.18.tgz"
@@ -3085,15 +3135,15 @@ escape-html@~1.0.3:
   resolved "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
-  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
-
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 eslint-config-prettier@^8.3.0:
   version "8.3.0"
@@ -3194,10 +3244,10 @@ eslint-scope@5.1.1, eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-scope@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz"
-  integrity sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==
+eslint-scope@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
+  integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
@@ -3214,15 +3264,10 @@ eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz"
-  integrity sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==
-
-eslint-visitor-keys@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz#6fbb166a6798ee5991358bc2daa1ba76cc1254a1"
-  integrity sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==
+eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint-webpack-plugin@^3.1.1:
   version "3.1.1"
@@ -3235,12 +3280,12 @@ eslint-webpack-plugin@^3.1.1:
     normalize-path "^3.0.0"
     schema-utils "^3.1.1"
 
-eslint@8.8.0:
-  version "8.8.0"
-  resolved "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz#9762b49abad0cb4952539ffdb0a046392e571a2d"
-  integrity sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==
+eslint@8.9.0, "eslint@^7.32.0 || ^8.2.0":
+  version "8.9.0"
+  resolved "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz#a2a8227a99599adc4342fd9b854cb8d8d6412fdb"
+  integrity sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==
   dependencies:
-    "@eslint/eslintrc" "^1.0.5"
+    "@eslint/eslintrc" "^1.1.0"
     "@humanwhocodes/config-array" "^0.9.2"
     ajv "^6.10.0"
     chalk "^4.0.0"
@@ -3248,10 +3293,10 @@ eslint@8.8.0:
     debug "^4.3.2"
     doctrine "^3.0.0"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^7.1.0"
+    eslint-scope "^7.1.1"
     eslint-utils "^3.0.0"
-    eslint-visitor-keys "^3.2.0"
-    espree "^9.3.0"
+    eslint-visitor-keys "^3.3.0"
+    espree "^9.3.1"
     esquery "^1.4.0"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
@@ -3276,16 +3321,16 @@ eslint@8.8.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^9.2.0, espree@^9.3.0:
-  version "9.3.0"
-  resolved "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz"
-  integrity sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==
+espree@^9.3.1:
+  version "9.3.1"
+  resolved "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz#8793b4bc27ea4c778c19908e0719e7b8f4115bcd"
+  integrity sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==
   dependencies:
     acorn "^8.7.0"
     acorn-jsx "^5.3.1"
-    eslint-visitor-keys "^3.1.0"
+    eslint-visitor-keys "^3.3.0"
 
-esprima@^4.0.0, esprima@~4.0.0:
+esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -3334,7 +3379,7 @@ events@^3.2.0:
   resolved "https://registry.npmjs.org/events/-/events-3.3.0.tgz"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-execa@5.1.1, execa@^5.0.0:
+execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
@@ -3407,7 +3452,7 @@ fast-diff@^1.1.2:
   resolved "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-glob@3.2.11, fast-glob@^3.2.11:
+fast-glob@^3.2.11:
   version "3.2.11"
   resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -3472,13 +3517,6 @@ file-loader@^6.2.0:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
-
-filelist@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz"
-  integrity sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==
-  dependencies:
-    minimatch "^3.0.4"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -3581,16 +3619,6 @@ fs-extra@^10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz"
-  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
 fs-monkey@1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz"
@@ -3634,11 +3662,6 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
-
-get-package-type@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz"
-  integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
 get-stdin@^8.0.0:
   version "8.0.0"
@@ -3725,7 +3748,7 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.0, globby@^11.0.4, globby@^11.1.0:
+globby@^11.0.4, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -3983,11 +4006,6 @@ human-signals@^2.1.0:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-hyperlinker@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz"
-  integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
-
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
@@ -4160,11 +4178,6 @@ is-date-object@^1.0.1:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-docker@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz"
-  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
-
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
@@ -4294,13 +4307,6 @@ is-weakref@^1.0.1:
   dependencies:
     call-bind "^1.0.2"
 
-is-wsl@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz"
-  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
-  dependencies:
-    is-docker "^2.0.0"
-
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
@@ -4310,16 +4316,6 @@ isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-jake@^10.6.1:
-  version "10.8.2"
-  resolved "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz"
-  integrity sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==
-  dependencies:
-    async "0.9.x"
-    chalk "^2.4.2"
-    filelist "^1.0.1"
-    minimatch "^3.0.4"
 
 jest-worker@^27.0.2, jest-worker@^27.0.6, jest-worker@^27.3.1:
   version "27.4.5"
@@ -5054,11 +5050,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-natural-orderby@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz#8623bc518ba162f8ff1cdb8941d74deb0fdcc016"
-  integrity sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz"
@@ -5068,11 +5059,6 @@ neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-nice-try@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz"
-  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 no-case@^3.0.4:
   version "3.0.4"
@@ -5160,11 +5146,6 @@ object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
-
-object-treeify@^1.1.4:
-  version "1.1.33"
-  resolved "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz"
-  integrity sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==
 
 object.assign@^4.1.0, object.assign@^4.1.2:
   version "4.1.2"
@@ -5369,14 +5350,6 @@ pascal-case@^3.1.2:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
-password-prompt@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.2.tgz"
-  integrity sha512-bpuBhROdrhuN3E7G/koAju0WjVw9/uQOG5Co5mokNj0MiOSBVZS1JTwM4zl55hu0WFmIEFvO9cU9sJQiBIYeIA==
-  dependencies:
-    ansi-escapes "^3.1.0"
-    cross-spawn "^6.0.5"
-
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
@@ -5396,11 +5369,6 @@ path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
-
-path-key@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
-  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
@@ -5496,21 +5464,21 @@ postcss-calc@^8.0.0:
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.0.2"
 
-postcss-clamp@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/postcss-clamp/-/postcss-clamp-3.0.0.tgz#09cb1ad64243b46c9159ded5e8d3e8349150a09e"
-  integrity sha512-QENQMIF/Grw0qX0RzSPJjw+mAiGPIwG2AnsQDIoR/WJ5Q19zLB0NrZX8cH7CzzdDWEerTPGCdep7ItFaAdtItg==
+postcss-clamp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/postcss-clamp/-/postcss-clamp-4.0.0.tgz#766d3dbaa2dc56e8bea1b690291b632c0c5bf728"
+  integrity sha512-FsMmeBZtymFN7Jtlnw9is8I4nB+qEEb/qS0ZLTIqcKiwZyHBq44Yhv29Q+VQsTGHYFqIr/s/9tqvNM7j+j1d+g==
   dependencies:
-    postcss-value-parser "^4.1.0"
+    postcss-value-parser "^4.2.0"
 
-postcss-color-functional-notation@^4.2.1:
+postcss-color-functional-notation@^4.2.2:
   version "4.2.2"
   resolved "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-4.2.2.tgz#f59ccaeb4ee78f1b32987d43df146109cc743073"
   integrity sha512-DXVtwUhIk4f49KK5EGuEdgx4Gnyj6+t2jBSEmxvpIK9QI40tWrpS2Pua8Q7iIZWBrki2QOaeUdEaLPPa91K0RQ==
   dependencies:
     postcss-value-parser "^4.2.0"
 
-postcss-color-hex-alpha@^8.0.2:
+postcss-color-hex-alpha@^8.0.3:
   version "8.0.3"
   resolved "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-8.0.3.tgz#61a0fd151d28b128aa6a8a21a2dad24eebb34d52"
   integrity sha512-fESawWJCrBV035DcbKRPAVmy21LpoyiXdPTuHUfWJ14ZRjY7Y7PA6P4g8z6LQGYhU1WAxkTxjIjurXzoe68Glw==
@@ -5560,7 +5528,7 @@ postcss-custom-selectors@^6.0.0:
   dependencies:
     postcss-selector-parser "^6.0.4"
 
-postcss-dir-pseudo-class@^6.0.3:
+postcss-dir-pseudo-class@^6.0.4:
   version "6.0.4"
   resolved "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-6.0.4.tgz#9afe49ea631f0cb36fa0076e7c2feb4e7e3f049c"
   integrity sha512-I8epwGy5ftdzNWEYok9VjW9whC4xnelAtbajGv4adql4FIF09rnrxnA9Y8xSHN47y7gqFIv10C5+ImsLeJpKBw==
@@ -5587,28 +5555,29 @@ postcss-discard-overridden@^5.0.1:
   resolved "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz"
   integrity sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==
 
-postcss-double-position-gradients@^3.0.4:
-  version "3.0.5"
-  resolved "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-3.0.5.tgz#f6b755e9850bb9816dfbf8fa346d9ce2e8a03848"
-  integrity sha512-XiZzvdxLOWZwtt/1GgHJYGoD9scog/DD/yI5dcvPrXNdNDEv7T53/6tL7ikl+EM3jcerII5/XIQzd1UHOdTi2w==
+postcss-double-position-gradients@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-3.1.0.tgz#a8614fb3a2a4b8877bffb8961b770e00322bbad1"
+  integrity sha512-oz73I08yMN3oxjj0s8mED1rG+uOYoK3H8N9RjQofyg52KBRNmePJKg3fVwTpL2U5ZFbCzXoZBsUD/CvZdlqE4Q==
   dependencies:
+    "@csstools/postcss-progressive-custom-properties" "^1.1.0"
     postcss-value-parser "^4.2.0"
 
-postcss-env-function@^4.0.4:
+postcss-env-function@^4.0.5:
   version "4.0.5"
   resolved "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-4.0.5.tgz#b9614d50abd91e4c88a114644a9766880dabe393"
   integrity sha512-gPUJc71ji9XKyl0WSzAalBeEA/89kU+XpffpPxSaaaZ1c48OL36r1Ep5R6+9XAPkIiDlSvVAwP4io12q/vTcvA==
   dependencies:
     postcss-value-parser "^4.2.0"
 
-postcss-focus-visible@^6.0.3:
+postcss-focus-visible@^6.0.4:
   version "6.0.4"
   resolved "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-6.0.4.tgz#50c9ea9afa0ee657fb75635fabad25e18d76bf9e"
   integrity sha512-QcKuUU/dgNsstIK6HELFRT5Y3lbrMLEOwG+A4s5cA+fx3A3y/JTq3X9LaOj3OC3ALH0XqyrgQIgey/MIZ8Wczw==
   dependencies:
     postcss-selector-parser "^6.0.9"
 
-postcss-focus-within@^5.0.3:
+postcss-focus-within@^5.0.4:
   version "5.0.4"
   resolved "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-5.0.4.tgz#5b1d2ec603195f3344b716c0b75f61e44e8d2e20"
   integrity sha512-vvjDN++C0mu8jz4af5d52CB184ogg/sSxAFS+oUJQq2SuCe7T5U2iIsVJtsCp2d6R4j0jr5+q3rPkBVZkXD9fQ==
@@ -5620,12 +5589,12 @@ postcss-font-variant@^5.0.0:
   resolved "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz"
   integrity sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==
 
-postcss-gap-properties@^3.0.2:
+postcss-gap-properties@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.3.tgz#6401bb2f67d9cf255d677042928a70a915e6ba60"
   integrity sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==
 
-postcss-image-set-function@^4.0.5:
+postcss-image-set-function@^4.0.6:
   version "4.0.6"
   resolved "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-4.0.6.tgz#bcff2794efae778c09441498f40e0c77374870a9"
   integrity sha512-KfdC6vg53GC+vPd2+HYzsZ6obmPqOk6HY09kttU19+Gj1nC3S3XBVEXDHxkhxTohgZqzbUb94bKXvKDnYWBm/A==
@@ -5653,11 +5622,12 @@ postcss-js@^4.0.0:
   dependencies:
     camelcase-css "^2.0.1"
 
-postcss-lab-function@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-4.0.4.tgz#504747ab2754e046fb01e72779bbb434a05357df"
-  integrity sha512-TAEW8X/ahMYV33mvLFQARtBPAy1VVJsiR9VVx3Pcbu+zlqQj0EIyJ/Ie1/EwxwIt530CWtEDzzTXBDzfdb+qIQ==
+postcss-lab-function@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-4.1.1.tgz#8b37dfcb9ca4ff82bbe7192c7ba3cc2bccbc0ef1"
+  integrity sha512-j3Z0WQCimY2tMle++YcmygnnVbt6XdnrCV1FO2IpzaCSmtTF2oO8h4ZYUA1Q+QHYroIiaWPvNHt9uBR4riCksQ==
   dependencies:
+    "@csstools/postcss-progressive-custom-properties" "^1.1.0"
     postcss-value-parser "^4.2.0"
 
 postcss-load-config@^3.1.0:
@@ -5678,7 +5648,7 @@ postcss-loader@6.2.1:
     klona "^2.0.5"
     semver "^7.3.5"
 
-postcss-logical@^5.0.3:
+postcss-logical@^5.0.4:
   version "5.0.4"
   resolved "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz#ec75b1ee54421acc04d5921576b7d8db6b0e6f73"
   integrity sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==
@@ -5867,7 +5837,7 @@ postcss-ordered-values@^5.0.2:
     cssnano-utils "^2.0.1"
     postcss-value-parser "^4.1.0"
 
-postcss-overflow-shorthand@^3.0.2:
+postcss-overflow-shorthand@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.3.tgz#ebcfc0483a15bbf1b27fdd9b3c10125372f4cbc2"
   integrity sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg==
@@ -5877,58 +5847,62 @@ postcss-page-break@^3.0.4:
   resolved "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz"
   integrity sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==
 
-postcss-place@^7.0.3:
+postcss-place@^7.0.4:
   version "7.0.4"
   resolved "https://registry.npmjs.org/postcss-place/-/postcss-place-7.0.4.tgz#eb026650b7f769ae57ca4f938c1addd6be2f62c9"
   integrity sha512-MrgKeiiu5OC/TETQO45kV3npRjOFxEHthsqGtkh3I1rPbZSbXGD/lZVi9j13cYh+NA8PIAPyk6sGjT9QbRyvSg==
   dependencies:
     postcss-value-parser "^4.2.0"
 
-postcss-preset-env@7.3.1:
-  version "7.3.1"
-  resolved "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.3.1.tgz#f17c609cfab3432620b92888464f92b4dba5eca0"
-  integrity sha512-x7fNsJxfkY60P4FUNwhJUOfXBFfnObd2EcUYY97sXZ0XRLgmAE65es9EFIYHq1rAk7X3LMfbG+L9wYgkrNsq5Q==
+postcss-preset-env@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.4.1.tgz#ca6131c6e0d0e0bcc429dbef3e8f8d03250041ea"
+  integrity sha512-UvBVvPJ2vb4odAtckSbryndyBz+Me1q8wawqq0qznpDXy188I+8W5Sa929sCPqw2/NSYnqpHJbo41BKso3+I9A==
   dependencies:
+    "@csstools/postcss-color-function" "^1.0.2"
     "@csstools/postcss-font-format-keywords" "^1.0.0"
     "@csstools/postcss-hwb-function" "^1.0.0"
+    "@csstools/postcss-ic-unit" "^1.0.0"
     "@csstools/postcss-is-pseudo-class" "^2.0.0"
     "@csstools/postcss-normalize-display-values" "^1.0.0"
+    "@csstools/postcss-oklab-function" "^1.0.1"
+    "@csstools/postcss-progressive-custom-properties" "^1.2.0"
     autoprefixer "^10.4.2"
     browserslist "^4.19.1"
-    css-blank-pseudo "^3.0.2"
-    css-has-pseudo "^3.0.3"
+    css-blank-pseudo "^3.0.3"
+    css-has-pseudo "^3.0.4"
     css-prefers-color-scheme "^6.0.3"
-    cssdb "^6.1.0"
+    cssdb "^6.3.1"
     postcss-attribute-case-insensitive "^5.0.0"
-    postcss-clamp "^3.0.0"
-    postcss-color-functional-notation "^4.2.1"
-    postcss-color-hex-alpha "^8.0.2"
+    postcss-clamp "^4.0.0"
+    postcss-color-functional-notation "^4.2.2"
+    postcss-color-hex-alpha "^8.0.3"
     postcss-color-rebeccapurple "^7.0.2"
     postcss-custom-media "^8.0.0"
     postcss-custom-properties "^12.1.4"
     postcss-custom-selectors "^6.0.0"
-    postcss-dir-pseudo-class "^6.0.3"
-    postcss-double-position-gradients "^3.0.4"
-    postcss-env-function "^4.0.4"
-    postcss-focus-visible "^6.0.3"
-    postcss-focus-within "^5.0.3"
+    postcss-dir-pseudo-class "^6.0.4"
+    postcss-double-position-gradients "^3.1.0"
+    postcss-env-function "^4.0.5"
+    postcss-focus-visible "^6.0.4"
+    postcss-focus-within "^5.0.4"
     postcss-font-variant "^5.0.0"
-    postcss-gap-properties "^3.0.2"
-    postcss-image-set-function "^4.0.5"
+    postcss-gap-properties "^3.0.3"
+    postcss-image-set-function "^4.0.6"
     postcss-initial "^4.0.1"
-    postcss-lab-function "^4.0.3"
-    postcss-logical "^5.0.3"
+    postcss-lab-function "^4.1.1"
+    postcss-logical "^5.0.4"
     postcss-media-minmax "^5.0.0"
     postcss-nesting "^10.1.2"
     postcss-opacity-percentage "^1.1.2"
-    postcss-overflow-shorthand "^3.0.2"
+    postcss-overflow-shorthand "^3.0.3"
     postcss-page-break "^3.0.4"
-    postcss-place "^7.0.3"
-    postcss-pseudo-class-any-link "^7.1.0"
+    postcss-place "^7.0.4"
+    postcss-pseudo-class-any-link "^7.1.1"
     postcss-replace-overflow-wrap "^4.0.0"
     postcss-selector-not "^5.0.0"
 
-postcss-pseudo-class-any-link@^7.1.0:
+postcss-pseudo-class-any-link@^7.1.1:
   version "7.1.1"
   resolved "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.1.1.tgz#534eb1dadd9945eb07830dbcc06fb4d5d865b8e0"
   integrity sha512-JRoLFvPEX/1YTPxRxp1JO4WxBVXJYrSY7NHeak5LImwJ+VobFMwYDQHvfTXEpcn+7fYIeGkC29zYFhFWIZD8fg==
@@ -6241,13 +6215,6 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-redeyed@~2.1.0:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz"
-  integrity sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=
-  dependencies:
-    esprima "~4.0.0"
-
 regenerate-unicode-properties@^9.0.0:
   version "9.0.0"
   resolved "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz"
@@ -6535,7 +6502,7 @@ schema-utils@^4.0.0:
     ajv-formats "^2.1.1"
     ajv-keywords "^5.0.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.5.0:
+"semver@2 || 3 || 4 || 5":
   version "5.7.1"
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -6610,24 +6577,12 @@ shallowequal@^1.1.0:
   resolved "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
-shebang-command@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz"
-  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
-  dependencies:
-    shebang-regex "^1.0.0"
-
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"
   integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
     shebang-regex "^3.0.0"
-
-shebang-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
-  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
 shebang-regex@^3.0.0:
   version "3.0.0"
@@ -6960,7 +6915,7 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.0.0, supports-color@^8.1.1:
+supports-color@^8.0.0:
   version "8.1.1"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -7009,10 +6964,10 @@ table@^6.8.0:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-tailwindcss@3.0.19:
-  version "3.0.19"
-  resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.19.tgz#cd789953e6762af2e80c5a3e5d6da3a975ee8215"
-  integrity sha512-rjsdfz/qZya5xQ0OVynEMETgWq1CacmftgMYeXXh6bRM5vxsNwRSbMJsCCIjq/w67om9VP/AFMolOwiE+5VKig==
+tailwindcss@3.0.23:
+  version "3.0.23"
+  resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.23.tgz#c620521d53a289650872a66adfcb4129d2200d10"
+  integrity sha512-+OZOV9ubyQ6oI2BXEhzw4HrqvgcARY38xv3zKcjnWtMIZstEsXdI9xftd1iB7+RbOnj2HOEzkA0OyB5BaSxPQA==
   dependencies:
     arg "^5.0.1"
     chalk "^4.1.2"
@@ -7027,6 +6982,7 @@ tailwindcss@3.0.19:
     is-glob "^4.0.3"
     normalize-path "^3.0.0"
     object-hash "^2.2.0"
+    postcss "^8.4.6"
     postcss-js "^4.0.0"
     postcss-load-config "^3.1.0"
     postcss-nested "5.0.6"
@@ -7144,6 +7100,23 @@ tslib@2.3.1, tslib@^2.0.3, tslib@^2.3.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
+tslib@^1.8.1:
+  version "1.14.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tsutils@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
+  dependencies:
+    tslib "^1.8.1"
+
+typanion@3.7.1, typanion@^3.3.1:
+  version "3.7.1"
+  resolved "https://registry.npmjs.org/typanion/-/typanion-3.7.1.tgz#5fceb57a2fa0c0a5beca25a7e90ac2a420863709"
+  integrity sha512-g2QDI/ZLpuEor9EnJ1b7s9S2QSJgNCPBw9ZCSkQdqXNjg5ZQs4mASgW/elVifSxISFwBeMaIAmMBP5luAOIKAw==
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz"
@@ -7160,11 +7133,6 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
-
-type-fest@^0.21.3:
-  version "0.21.3"
-  resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz"
-  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 type-fest@^0.6.0:
   version "0.6.0"
@@ -7531,7 +7499,7 @@ which-boxed-primitive@^1.0.2:
     is-string "^1.0.5"
     is-symbol "^1.0.3"
 
-which@^1.2.9, which@^1.3.1:
+which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -7544,13 +7512,6 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
-
-widest-line@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz"
-  integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
-  dependencies:
-    string-width "^4.0.0"
 
 wildcard@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### update to [bud v5.4.0](https://github.com/roots/bud/releases/tag/v5.4.0)

- uses `@roots/eslint-config/sage`
- refactors `resources/scripts` boilerplate so dom and hmr events share the same entrypoint callback
