### PR TITLE
🔥 remove default palette + gradients from theme.json

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -11,7 +11,9 @@
         }
       ],
       "custom": false,
-      "customGradient": false
+      "customGradient": false,
+      "defaultPalette": false,
+      "defaultGradients": false
     },
     "custom": {
       "spacing": {},


### PR DESCRIPTION
Assuming most people using Sage will be defining their own palette, might be worth removing the defaults WP throws in there?

<table>
<tr>
<th>before</th>
<th>after</th>
<tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/1690006/157415843-40db6eab-b1f0-4d01-ba36-97aa973aae40.jpg" />
</td>
<td>
<img src="https://user-images.githubusercontent.com/1690006/157415839-09b146cb-4249-44bd-b8cd-cee8db8a83cc.jpg" />
</td>
</tr>
</table>

