### PR TITLE
🔥 remove `add_theme_support('align-wide')`

### DIFF
--- a/app/setup.php
+++ b/app/setup.php
@@ -77,12 +77,6 @@ add_action('after_setup_theme', function () {
     add_theme_support('post-thumbnails');
 
     /**
-     * Enable wide alignment support.
-     * @link https://wordpress.org/gutenberg/handbook/designers-developers/developers/themes/theme-support/#wide-alignment
-     */
-    add_theme_support('align-wide');
-
-    /**
      * Enable responsive embed support.
      * @link https://wordpress.org/gutenberg/handbook/designers-developers/developers/themes/theme-support/#responsive-embedded-content
      */


### PR DESCRIPTION
`add_theme_support('align-wide')` doesn't work with a `theme.json` file present.

if you're looking to add this setting for the editor, you'll need to configure it in `theme.json`.

ref https://fullsiteediting.com/lessons/theme-json-layout-and-spacing-options/

closes #3007