### PR TITLE
🔧 Improve translation scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,12 @@
   "scripts": {
     "dev": "bud dev",
     "build": "bud build",
-    "translate": "npm run translate:pot && npm run translate:js",
-    "translate:pot": "wp i18n make-pot . ./resources/lang/sage.pot --ignore-domain --include=\"app,resources\"",
-    "translate:js": "wp i18n make-json ./resources/lang --pretty-print"
+    "translate": "npm run translate:pot && npm run translate:update",
+    "translate:pot": "wp i18n make-pot . ./resources/lang/sage.pot --include=\"app,resources\"",
+    "translate:update": "for filename in ./resources/lang/*.po; do msgmerge -U $filename ./resources/lang/sage.pot; done; rm -f ./resources/lang/*.po~",
+    "translate:compile": "npm run translate:mo && npm run translate:js",
+    "translate:js": "wp i18n make-json ./resources/lang --pretty-print",
+    "translate:mo": "wp i18n make-mo ./resources/lang ./resources/lang"
   },
   "devDependencies": {
     "@roots/bud": "5.6.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "translate": "yarn translate:pot && yarn translate:update",
     "translate:pot": "wp i18n make-pot . ./resources/lang/sage.pot --include=\"app,resources\"",
     "translate:update": "for filename in ./resources/lang/*.po; do msgmerge -U $filename ./resources/lang/sage.pot; done; rm -f ./resources/lang/*.po~",
-    "translate:compile": "npm run translate:mo && npm run translate:js",
+    "translate:compile": "yarn translate:mo && yarn translate:js",
     "translate:js": "wp i18n make-json ./resources/lang --pretty-print",
     "translate:mo": "wp i18n make-mo ./resources/lang ./resources/lang"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "bud dev",
     "build": "bud build",
-    "translate": "npm run translate:pot && npm run translate:update",
+    "translate": "yarn translate:pot && yarn translate:update",
     "translate:pot": "wp i18n make-pot . ./resources/lang/sage.pot --include=\"app,resources\"",
     "translate:update": "for filename in ./resources/lang/*.po; do msgmerge -U $filename ./resources/lang/sage.pot; done; rm -f ./resources/lang/*.po~",
     "translate:compile": "npm run translate:mo && npm run translate:js",


### PR DESCRIPTION
This PR adds more and improves existing translation related `npm` scripts:


## `npm` scripts
- `translate`: Run `translate:pot` and `translate:update`.
This is used to update the `PO` files to the latest translatable strings in the theme.
  - `translate:pot`: Update the Poedit Template (`POT`) file from the theme files.
  - `translate:update`: Update `PO` translation files (for a specific locale, e.g. `de_DE`) from the Poedit Template (`POT`) file.

- `translate:compile`: Run `translate:js` and `translate:mo`.
This is used to compile all the `PO` files to `JSON` and `MO` for usage in PHP/JavaScript/WordPress.
  - `translate:js`: Generate the JavaScript `JSON` translation files from `PO` files, used by JavaScript related WordPress components like Gutenberg Blocks in the Gutenberg Editor.
  - `translate:mo`: Compile `PO` translation files to compiled, efficient `MO` files that are used by PHP/WordPress.


## Workflow:
- `npm run translate` to scan and update the `PO` translation files from the theme.
- Open and update the `PO` translation files with a suitable program (usually [PoEdit](https://poedit.net/)).
- `npm run translate:compile` to compile the `PO` translation files to `MO` files that can be used by PHP/WordPress and to JavaScript JSON files that can be used by WordPress JavaScript (Gutenberg).
- (Commit these translation-related changes).


## WP CLI `i18n` supporting versions
WP CLI `i18n` has support for parsing out translation strings from `Blade-PHP` templates now.
A new version of [`wp-cli/i18n-command`](https://github.com/wp-cli/i18n-command) that contains the merged PR should be released in the near future.
In the meantime, [installing `wp-cli/i18n-command` from the repository](https://github.com/wp-cli/i18n-command/pull/304#issuecomment-1066533103) can be used to get `PHP-Blade` support:
When you have a `i18n` release newer than `2.2.13` and WP CLI release newer than `2.6.0` installed, 
`PHP-Blade` support should be already included.
You can use `wp i18n make-pot --help | grep blade` and check whether `blade` is mentioned.
