### PR TITLE
🔧 Add index.php to tailwindcss purge list

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  content: ['./app/**/*.php', './resources/**/*.{php,vue,js}'],
+  content: ['./index.php', './app/**/*.php', './resources/**/*.{php,vue,js}'],
   theme: {
     extend: {
       colors: {},


### PR DESCRIPTION
Since `index.php` is a part of the views and can have `tailwindcss` classes, it makes sense to have it included into the purge content list to not miss any css classes there.