### PR TITLE
🐛 Fix i18n warnings

### DIFF
--- a/resources/views/partials/comments.blade.php
+++ b/resources/views/partials/comments.blade.php
@@ -2,7 +2,7 @@
   <section id="comments" class="comments">
     @if (have_comments())
       <h2>
-        {!! sprintf(_nx('One response to &ldquo;%2$s&rdquo;', '%1$s responses to &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'sage'), number_format_i18n(get_comments_number()), '<span>' . get_the_title() . '</span>') !!}
+        {!! /* translators: %1$s is replaced with the number of comments and %2$s with the post title */ sprintf(_nx('%1$s response to &ldquo;%2$s&rdquo;', '%1$s responses to &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'sage'), get_comments_number() === 1 ? _x('One', 'comments title', 'sage') : number_format_i18n(get_comments_number()), '<span>' . get_the_title() . '</span>') !!}
       </h2>
 
       <ol class="comment-list">


### PR DESCRIPTION
This PR fixes the i18n warnings by adding a missing translators comment and uses a singular placeholder.
For single comments, `One` is used instead of a number (in a `comments title` context), which fixes the 2nd i18n warning.

Edit: Fixed something and merged commits into one, hence the force-pushes...