### PR TITLE
🔧 bud config: set the public path by default

### DIFF
--- a/bud.config.js
+++ b/bud.config.js
@@ -37,5 +37,10 @@ module.exports = async (app) => {
     /**
      * Development URL to be used in the browser.
      */
-    .serve('http://0.0.0.0:3000');
+    .serve('http://0.0.0.0:3000')
+
+    /**
+     * Relative path to the public directory.
+     */
+    .setPublicPath('/app/themes/sage/public/');
 };


### PR DESCRIPTION
users will be less likely to run into issues when adding dynamic imports by configuring the public path when setting up the theme

[this was required for sage 9](https://github.com/roots/sage/blob/7e6d0671d3421acadb6e9b3d0bad2a9f54d62c67/resources/assets/config.json#L11)