### PR TITLE
🔧 Use `wp i18n update-po` for updating PO files

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "bud build",
     "translate": "yarn translate:pot && yarn translate:update",
     "translate:pot": "wp i18n make-pot . ./resources/lang/sage.pot --include=\"app,resources\"",
-    "translate:update": "for filename in ./resources/lang/*.po; do msgmerge -U $filename ./resources/lang/sage.pot; done; rm -f ./resources/lang/*.po~",
+    "translate:update": "wp i18n update-po ./resources/lang/sage.pot ./resources/lang/*.po",
     "translate:compile": "yarn translate:mo && yarn translate:js",
     "translate:js": "wp i18n make-json ./resources/lang --pretty-print",
     "translate:mo": "wp i18n make-mo ./resources/lang ./resources/lang"


### PR DESCRIPTION
This PR replaces the existing shell script with a `wp i18n` invocation for the newly added `update-po` subcommand that updates the PO files with the POT file.

This eliminates the need for external tooling (except for the `wp` CLI of course) and shell scripts. 

The latest `wp i18n` version (>=[`2.4.0`](https://github.com/wp-cli/i18n-command/releases/tag/v2.4.0#:~:text=Add%20update%2Dpo%20command)) is needed for the newly added `update-po` subcommand.
Until `wp` CLI is also newly released with the new `wp i18n` version bundled, 
the latest `wp i18n` version can be installed independently from the `wp` CLI version by using 
`wp package install wp-cli/i18n-command:dev-main` 
and then just using it as usual (`wp i18n`).