### PR TITLE
🔧 Acorn v3 (Laravel 9.x), drop PHP 7.4 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['8.0', '8.1']
 
     steps:
       - name: Checkout the project

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Make sure all dependencies have been installed before moving on:
 
 - [Acorn](https://docs.roots.io/acorn/2.x/installation/) v2
 - [WordPress](https://wordpress.org/) >= 5.9
-- [PHP](https://secure.php.net/manual/en/install.php) >= 7.4.0 (with [`php-mbstring`](https://secure.php.net/manual/en/book.mbstring.php) enabled)
+- [PHP](https://secure.php.net/manual/en/install.php) >= 8.0 (with [`php-mbstring`](https://secure.php.net/manual/en/book.mbstring.php) enabled)
 - [Composer](https://getcomposer.org/download/)
 - [Node.js](http://nodejs.org/) >= 16
 - [Yarn](https://yarnpkg.com/en/docs/install)

--- a/app/Providers/ThemeServiceProvider.php
+++ b/app/Providers/ThemeServiceProvider.php
@@ -2,27 +2,8 @@
 
 namespace App\Providers;
 
-use Roots\Acorn\ServiceProvider;
+use Roots\Acorn\Sage\SageServiceProvider;
 
-class ThemeServiceProvider extends ServiceProvider
+class ThemeServiceProvider extends SageServiceProvider
 {
-    /**
-     * Register any application services.
-     *
-     * @return void
-     */
-    public function register()
-    {
-        //
-    }
-
-    /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        //
-    }
 }

--- a/app/Providers/ThemeServiceProvider.php
+++ b/app/Providers/ThemeServiceProvider.php
@@ -6,4 +6,23 @@ use Roots\Acorn\Sage\SageServiceProvider;
 
 class ThemeServiceProvider extends SageServiceProvider
 {
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        parent::register();
+    }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        parent::boot();
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     }
   },
   "require": {
-    "php": "^7.4|^8.0"
+    "php": "^8.0"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "3.7.1"

--- a/functions.php
+++ b/functions.php
@@ -63,4 +63,3 @@ collect(['setup', 'filters'])
             );
         }
     });
-

--- a/functions.php
+++ b/functions.php
@@ -36,7 +36,7 @@ try {
         __('You need to install Acorn to use this theme.', 'sage'),
         '',
         [
-            'link_url' => 'https://docs.roots.io/acorn/3.x/installation/',
+            'link_url' => 'https://roots.io/acorn/docs/installation/',
             'link_text' => __('Acorn Docs: Installation', 'sage'),
         ]
     );

--- a/functions.php
+++ b/functions.php
@@ -30,13 +30,13 @@ require $composer;
 */
 
 try {
-    \Roots\bootloader();
+    \Roots\bootloader()->boot();
 } catch (Throwable $e) {
     wp_die(
         __('You need to install Acorn to use this theme.', 'sage'),
         '',
         [
-            'link_url' => 'https://docs.roots.io/acorn/2.x/installation/',
+            'link_url' => 'https://docs.roots.io/acorn/3.x/installation/',
             'link_text' => __('Acorn Docs: Installation', 'sage'),
         ]
     );
@@ -64,16 +64,3 @@ collect(['setup', 'filters'])
         }
     });
 
-/*
-|--------------------------------------------------------------------------
-| Enable Sage Theme Support
-|--------------------------------------------------------------------------
-|
-| Once our theme files are registered and available for use, we are almost
-| ready to boot our application. But first, we need to signal to Acorn
-| that we will need to initialize the necessary service providers built in
-| for Sage when booting.
-|
-*/
-
-add_theme_support('sage');


### PR DESCRIPTION
These changes are required to upgrade to Acorn v3

TODOs

* [x] Acorn v3 stable release
* [x] [Upgrade docs](https://roots.io/acorn/docs/guides/upgrading-acorn/) (https://github.com/roots/docs/issues/433)

Ref https://github.com/roots/acorn/releases