### PR TITLE
Add .env to set proxy used in bud config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+PROXY='http://example.test'

--- a/bud.config.mjs
+++ b/bud.config.mjs
@@ -29,7 +29,7 @@ export default async (app) => {
     /**
      * Proxy origin (`WP_HOME`)
      */
-    .proxy("http://example.test")
+    .proxy(process.env.PROXY || "http://example.test")
 
     /**
      * Development origin


### PR DESCRIPTION
Some development environments such as Valet use `.test`, but some others such as Localwp use `.local`
Adding an `.env` file to set the proxy to use in bud config can be helpful when working with other developers who using different development environments.