### PR TITLE
:wrench: Wait for CSS to be loaded before init JS

### DIFF
--- a/resources/scripts/app.js
+++ b/resources/scripts/app.js
@@ -16,6 +16,13 @@ const main = async (err) => {
  * Initialize
  *
  * @see https://webpack.js.org/api/hot-module-replacement
+ * @returns { void }
  */
-domReady(main);
-import.meta.webpackHot?.accept(main);
+if (module.hot) {
+  window.addEventListener('load', (event) => {
+    main();
+    import.meta.webpackHot?.accept(main);
+  });
+} else {
+  domReady(main);
+}


### PR DESCRIPTION
In development, CSS is injected and not included via a file. To be able to use correctly some JS functions that depend on style (`el.scrollWidth`, etc.), we have to wait until the CSS is injected and parsed.