### PR TITLE
🔥 Remove default duotone filters from theme.json

### DIFF
--- a/bud.config.mjs
+++ b/bud.config.mjs
@@ -53,6 +53,7 @@ export default async (app) => {
           customDuotone: false,
           customGradient: false,
           defaultDuotone: false,
+          defaultGradients: false,
           defaultPalette: false,
           duotone: [],
         },

--- a/bud.config.mjs
+++ b/bud.config.mjs
@@ -55,7 +55,6 @@ export default async (app) => {
           defaultDuotone: false,
           defaultPalette: false,
           duotone: [],
-          gradients: [],
         },
         custom: {
           spacing: {},

--- a/bud.config.mjs
+++ b/bud.config.mjs
@@ -50,9 +50,12 @@ export default async (app) => {
       .settings({
         color: {
           custom: false,
+          customDuotone: false,
           customGradient: false,
+          defaultDuotone: false,
           defaultPalette: false,
-          defaultGradients: false,
+          duotone: [],
+          gradients: [],
         },
         custom: {
           spacing: {},


### PR DESCRIPTION
~~Default gradient swatches reappeared in the palette as of WordPress 6.1. The empty `gradients` array removes them.~~

This also removes duotone filters as while we're at it.