### PR TITLE
💡 Update WordPress documentation links

### DIFF
--- a/app/setup.php
+++ b/app/setup.php
@@ -84,7 +84,7 @@ add_action('after_setup_theme', function () {
     /**
      * Enable responsive embed support.
      *
-     * @link https://wordpress.org/gutenberg/handbook/designers-developers/developers/themes/theme-support/#responsive-embedded-content
+     * @link https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#responsive-embedded-content
      */
     add_theme_support('responsive-embeds');
 
@@ -106,7 +106,7 @@ add_action('after_setup_theme', function () {
     /**
      * Enable selective refresh for widgets in customizer.
      *
-     * @link https://developer.wordpress.org/themes/advanced-topics/customizer-api/#theme-support-in-sidebars
+     * @link https://developer.wordpress.org/reference/functions/add_theme_support/#customize-selective-refresh-widgets
      */
     add_theme_support('customize-selective-refresh-widgets');
 }, 20);


### PR DESCRIPTION
Noticed some `after_setup_theme` links were outdated.