### PR TITLE
🧑‍💻 Check that the Acorn bootloader exists before booting

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -29,9 +29,7 @@ require $composer;
 |
 */
 
-try {
-    \Roots\bootloader()->boot();
-} catch (Throwable $e) {
+if (! function_exists('\Roots\bootloader')) {
     wp_die(
         __('You need to install Acorn to use this theme.', 'sage'),
         '',
@@ -41,6 +39,8 @@ try {
         ]
     );
 }
+
+\Roots\bootloader()->boot();
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
This PR along with https://github.com/roots/acorn/pull/266 helps better understand when a service provider is causing something to break