### PR TITLE
Display CPT label in title instead of default

### DIFF
--- a/app/View/Composers/Post.php
+++ b/app/View/Composers/Post.php
@@ -48,6 +48,13 @@ class Post extends Composer
             return __('Latest Posts', 'sage');
         }
 
+        // CPT: "My post type" instead of "Archives: MyPostTypes"
+        if (is_post_type_archive()) {
+            $labels = get_post_type_labels(get_post_type_object(get_post_type()));
+            if ($labels->name)
+                return $labels->name;
+        }
+
         if (is_archive()) {
             return get_the_archive_title();
         }


### PR DESCRIPTION
Given a CPT "Pets"

Instead of "Archives: Pets", show "Pets" 

![image](https://user-images.githubusercontent.com/4065733/235819948-03bc6444-1a15-4017-ad31-64a3558aad23.png)
![image](https://user-images.githubusercontent.com/4065733/235819977-3d57ae15-9e7f-473d-adaa-0686e49b6d0f.png)

## How to test

###  the usual install

```
git clone git@github.com:roots/sage.git && cd sage
composer require roots/acorn
composer install
yarn && yarn build
wp theme activate sage
```

### add ui for post types

`wp plugin install --activate custom-post-type-ui
`
### add pet cpt

![add post type](https://user-images.githubusercontent.com/4065733/235820038-3051fd53-53b0-4b3a-9276-a76211323976.png)


### add a dog and a cat

### navigate to archive

example: 

`http://wp.localhost/pet/
`