### PR TITLE
Update bud.config.js with missing ProxyURL port number

### DIFF
--- a/bud.config.js
+++ b/bud.config.js
@@ -34,7 +34,7 @@ export default async (app) => {
    */
   app
     .setUrl('http://localhost:3000')
-    .setProxyUrl('http://example.test')
+    .setProxyUrl('http://example.test:3000')
     .watch(['resources/views', 'app']);
 
   /**


### PR DESCRIPTION
Missing port number breaks `yarn dev` command, and returns the following error: `Error occurred while trying to proxy: localhost:3000/`

Documentation regarding this problem can be found here: https://discourse.roots.io/t/problems-with-sage-installation-on-macos/25864

Port number [appears as well in bud.js documentation](https://bud.js.org/learn/config/dev-server#setting-public-urls)