### PR TITLE
fix: update default app.css tailwind syntax to use @tailwind (#3149)

### DIFF
--- a/resources/styles/app.css
+++ b/resources/styles/app.css
@@ -1,3 +1,3 @@
-@import 'tailwindcss/base';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
Minor change to switch from older `@import 'tailwindcss/...` syntax to `@tailwind` as recommended in Tailwind docs.

This encourages users to avoid a possible cache invalidation issue.

See: https://tailwindcss.com/docs/installation#:~:text=Add%20the%20Tailwind,main%20CSS%20file.
See: https://github.com/roots/bud/issues/2455

The cache invalidation logic for `@tailwind` was introduced in Tailwind 3.0.24. [Sage's app.css was written originally for Tailwind 2.0.2 on Sage 10.0.0-beta.1](https://github.com/roots/sage/commit/5518ea165abadebff284c8cdfa32d6bab86f913a)