### PR TITLE
✨ Editor: Add background image support

### DIFF
--- a/bud.config.js
+++ b/bud.config.js
@@ -47,6 +47,9 @@ export default async (app) => {
    */
   app.wpjson
     .setSettings({
+      background: {
+        backgroundImage: true,
+      },
       color: {
         custom: false,
         customDuotone: false,

--- a/theme.json
+++ b/theme.json
@@ -3,6 +3,9 @@
   "$schema": "https://schemas.wp.org/trunk/theme.json",
   "version": 2,
   "settings": {
+    "background": {
+      "backgroundImage": true
+    },
     "color": {
       "custom": false,
       "customDuotone": false,


### PR DESCRIPTION
Enable background images for group blocks

Ref https://make.wordpress.org/core/2023/10/17/miscellaneous-editor-changes-in-wordpress-6-4/#how-to-add-backgroundimage-support-to-a-theme

h/t @hofmannsven via https://github.com/roots/radicle/issues/98