### PR TITLE
🩹 Comments title: Fix make-pot warning

### DIFF
--- a/app/View/Composers/Comments.php
+++ b/app/View/Composers/Comments.php
@@ -39,8 +39,8 @@ class Comments extends Composer
      */
     public function title()
     {
-        /* translators: %1$s is replaced with the number of comments and %2$s with the post title */
         return sprintf(
+            /* translators: %1$s is replaced with the number of comments and %2$s with the post title */
             _nx('%1$s response to &ldquo;%2$s&rdquo;', '%1$s responses to &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'sage'),
             get_comments_number() === 1 ? _x('One', 'comments title', 'sage') : number_format_i18n(get_comments_number()),
             '<span>'.get_the_title().'</span>'


### PR DESCRIPTION
Follow-up to #3162 that fixes this warning:

```
Warning: The string "%1$s response to &ldquo;%2$s&rdquo;" contains placeholders but has no "translators:" comment to clarify their meaning. (app/View/Composers/Comments.php:44)
```