### PR TITLE
Bump minimum PHP version to 8.1

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,6 +8,6 @@ Author URI:         https://roots.io/
 Text Domain:        sage
 License:            MIT License
 License URI:        https://opensource.org/licenses/MIT
-Requires PHP:       8.0
+Requires PHP:       8.1
 Requires at least:  5.9
 */


### PR DESCRIPTION
In #3176 the minimum PHP version is bumped to 8.1 - updated this also in `style.css`