### PR TITLE
fix: Deprecation errors in CI Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,18 +25,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+          cache: 'yarn'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Restore the Yarn cache directory
-        id: yarncache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v4
-        with:
-          path: ${{ steps.yarncache.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.node }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.node }}-yarn-
 
       - name: Install dependencies using Yarn
         run: yarn install --frozen-lockfile
@@ -65,11 +56,11 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
         env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore the Composer cache directory
         id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
# This PR Fixes
* We can now simply cache yarn by just specifying a `cache` key to actions/setup-node@v4
* Replace: deprecated `COMPOSER_TOKEN` variable in favor of `GITHUB_TOKEN`.
* fix: The set-output command is deprecated and will be disabled soon.

<img width="857" alt="Screenshot 2024-02-02 at 7 09 32 PM" src="https://github.com/roots/sage/assets/6929121/e3736e47-1476-4633-82ac-2f0a3c5e90ae">
<img width="1118" alt="Screenshot 2024-02-02 at 7 13 03 PM" src="https://github.com/roots/sage/assets/6929121/fedcf347-4dc1-49b8-8a41-4ca2fef3b0ca">
