### PR TITLE
🔧 Use `enqueue_block_assets` for editor assets

### DIFF
--- a/app/setup.php
+++ b/app/setup.php
@@ -22,7 +22,7 @@ add_action('wp_enqueue_scripts', function () {
  *
  * @return void
  */
-add_action('enqueue_block_editor_assets', function () {
+add_action('enqueue_block_assets', function () {
     bundle('editor')->enqueue();
 }, 100);
 


### PR DESCRIPTION
This PR fixes the following warning:

```
editor/0-css was added to the iframe incorrectly. Please use block.json or enqueue_block_assets to add styles to the iframe.
```

Ref #3185