### PR TITLE
add default aliases for assets

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -34,10 +34,10 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@scripts': '/resources/js',
-      '@styles': '/resources/css',
-      '@fonts': '/resources/fonts',
-      '@images': '/resources/images',
+      '@scripts': 'resources/js',
+      '@styles': 'resources/css',
+      '@fonts': 'resources/fonts',
+      '@images': 'resources/images',
     },
   },
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -32,4 +32,12 @@ export default defineConfig({
       disableTailwindFontSizes: false,
     }),
   ],
+  resolve: {
+    alias: {
+      '@scripts': '/resources/js',
+      '@styles': '/resources/css',
+      '@fonts': '/resources/fonts',
+      '@images': '/resources/images',
+    },
+  },
 })


### PR DESCRIPTION
Adds the same default aliases as the @roots/sage bud extension. Allows hashed asset paths to be referenced in css & js.
For example: ` background-color:url('@images/example.jpg');`