### PR TITLE
Fix theme.json generation to handle :host selector in app.css theme layer

### DIFF
--- a/resources/js/build/wordpress.js
+++ b/resources/js/build/wordpress.js
@@ -206,7 +206,7 @@ export function wordpressThemeJson({
       }
 
       const themeContent = themeMatch[1]
-      if (!themeContent.startsWith(':root{')) {
+      if (!themeContent.trim().startsWith(':root')) {
         return;
       }
 


### PR DESCRIPTION
Previously, `wordpressThemeJson` checked that `themeContent` starts with  `:root{`, but  Tailwind wraps theme layer  in  `:root, :host`, causing an early return.  Remove '{'  to support `:host` selector and add `trim()` for non-minified app.css.