### PR TITLE
Fix default aliases paths for assets

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -34,10 +34,10 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@scripts': 'resources/js',
-      '@styles': 'resources/css',
-      '@fonts': 'resources/fonts',
-      '@images': 'resources/images',
+      '@scripts': '/resources/js',
+      '@styles': '/resources/css',
+      '@fonts': '/resources/fonts',
+      '@images': '/resources/images',
     },
   },
 })


### PR DESCRIPTION
Setting absolute paths in aliases to prevent warnings in Vite.js and fix the background-image reference to an image using eg. @images/bg.svg

![before](https://github.com/user-attachments/assets/ee28aaf0-7c09-41ef-a045-d04063cfcaa8)
![after](https://github.com/user-attachments/assets/53e1a00c-366a-4328-92c8-43b120818728)
