### PR TITLE
Fix Vite dependency extract

### DIFF
--- a/resources/js/build/wordpress.js
+++ b/resources/js/build/wordpress.js
@@ -88,7 +88,7 @@ export function wordpressPlugin() {
       }
     },
     transform(code, id) {
-      if ((!id.endsWith('.js')) && !id.endsWith('.jsx')) return
+      if ((!id.endsWith('.js')) && !id.endsWith('.jsx') && !id.endsWith('.ts') && !id.endsWith('.tsx')) return
 
       const imports = [
         ...(code.match(/^import[\s\n]+(?:[^;]+?)[\s\n]+from[\s\n]+['"]@wordpress\/[^'"]+['"]/gm) || []),

--- a/resources/js/build/wordpress.js
+++ b/resources/js/build/wordpress.js
@@ -22,7 +22,10 @@ export function wordpressPlugin() {
   function extractNamedImports(imports) {
     const match = imports.match(/{([^}]+)}/)
     if (!match) return []
-    return match[1].split(',').map((s) => s.trim())
+    return match[1]
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s !== '')
   }
 
   function handleNamedReplacement(namedImports, external) {
@@ -88,14 +91,16 @@ export function wordpressPlugin() {
       if ((!id.endsWith('.js')) && !id.endsWith('.jsx')) return
 
       const imports = [
-        ...(code.match(/^import .+ from ['"]@wordpress\/[^'"]+['"]/gm) || []),
-        ...(code.match(/^import ['"]@wordpress\/[^'"]+['"]/gm) || []),
+        ...(code.match(/^import[\s\n]+(?:[^;]+?)[\s\n]+from[\s\n]+['"]@wordpress\/[^'"]+['"]/gm) || []),
+        ...(code.match(/^import[\s\n]+['"]@wordpress\/[^'"]+['"]/gm) || []),
       ]
 
       imports.forEach((statement) => {
         const match =
-          statement.match(/^import (.+) from ['"]@wordpress\/([^'"]+)['"]/) ||
-          statement.match(/^import ['"]@wordpress\/([^'"]+)['"]/)
+          statement
+            .replace(/[\s\n]+/g, ' ')
+            .match(/^import (.+) from ['"]@wordpress\/([^'"]+)['"]/) ||
+          statement.match(/^import ['"]@wordpress\/([^'"]+)['"]/);
 
         if (!match) return
 


### PR DESCRIPTION
Hey,
first of all, great job implementing Vite to the Sage, I love it!

Dependency extraction regex is working fine when imports are defined in single line, but not working when imports are defined using new lines, e.g.
```
import {
  InnerBlocks,
  InspectorControls,
  RichText,
  useBlockProps,
  useInnerBlocksProps,
} from '@wordpress/block-editor';
```
This PR should fix regex and add check if extracted import is not empty (last comma in import block was causing trouble).


Also I've added small fix for Typescript compatibility.