### PR TITLE
fix tailwind css regex mismatch

### DIFF
--- a/resources/js/build/wordpress.js
+++ b/resources/js/build/wordpress.js
@@ -200,12 +200,28 @@ export function wordpressThemeJson({
         fs.readFileSync(path.resolve('./theme.json'), 'utf8')
       )
 
-      const themeMatch = cssContent.match(/@(?:layer\s+)?theme\s*{([^}]*)}/s)
-      if (!themeMatch) {
+      const themeContent = (() => {
+        const match = cssContent.match(/@(?:layer\s+)?theme\s*{/s)
+        
+        if (!match[0]) {
+          return null
+        }
+        const startIndex = match.index + match[0].length;
+        let braceCount = 1;
+        for (let i = startIndex; i < cssContent.length; i++) { 
+          if (cssContent[i] === "{") braceCount++;
+          if (cssContent[i] === "}") braceCount--;
+          if (braceCount === 0) {
+            return cssContent.substring(startIndex, i );
+          }
+        }
+        return null
+      })()
+      
+      if (!themeContent) {
         return;
       }
-
-      const themeContent = themeMatch[1]
+      
       if (!themeContent.trim().startsWith(':root')) {
         return;
       }


### PR DESCRIPTION
Added a simple function that matches corresponding curly braces so the `@layer theme` content is correctly matched.

fixes #3220
