### PR TITLE
Compact fix for color generation in theme.json

### DIFF
--- a/resources/js/build/wordpress.js
+++ b/resources/js/build/wordpress.js
@@ -211,8 +211,8 @@ export function wordpressThemeJson({
       }
 
       const startIndex = themeContent.indexOf('{') + 1;
-      const endIndex = themeContent.lastIndexOf('}'); // This may not be present - if not, just slice to the end
-      const rootContent = endIndex === -1 ? themeContent.slice(startIndex) : themeContent.slice(startIndex, endIndex);
+      const endIndex = themeContent.lastIndexOf('}');
+      const rootContent = themeContent.slice(startIndex, endIndex === -1 ? undefined : endIndex);
       const colorVariables = {}
 
       const colorVarRegex = /--color-([^:]+):\s*([^;}]+)[;}]?/g

--- a/resources/js/build/wordpress.js
+++ b/resources/js/build/wordpress.js
@@ -210,7 +210,9 @@ export function wordpressThemeJson({
         return;
       }
 
-      const rootContent = themeContent.slice(themeContent.indexOf('{') + 1, themeContent.lastIndexOf('}'))
+      const startIndex = themeContent.indexOf('{') + 1;
+      const endIndex = themeContent.lastIndexOf('}'); // This may not be present - if not, just slice to the end
+      const rootContent = endIndex === -1 ? themeContent.slice(startIndex) : themeContent.slice(startIndex, endIndex);
       const colorVariables = {}
 
       const colorVarRegex = /--color-([^:]+):\s*([^;}]+)[;}]?/g

--- a/resources/js/build/wordpress.js
+++ b/resources/js/build/wordpress.js
@@ -210,9 +210,8 @@ export function wordpressThemeJson({
         return;
       }
 
-      const startIndex = themeContent.indexOf('{') + 1;
       const endIndex = themeContent.lastIndexOf('}');
-      const rootContent = themeContent.slice(startIndex, endIndex === -1 ? undefined : endIndex);
+      const rootContent = themeContent.slice(themeContent.indexOf('{') + 1, endIndex === -1 ? undefined : endIndex);
       const colorVariables = {}
 
       const colorVarRegex = /--color-([^:]+):\s*([^;}]+)[;}]?/g


### PR DESCRIPTION
While testing I found that the `themeContent` CSS sometimes does not contain a closing curly bracket, meaning the index of the last bracket was -1. This cut off the final `--color-example: #abcdef` definition by one character, leading to the generated theme.json color for that one to be:

````
{
          "name": "example",
          "slug": "example",
          "color": "#abcde"
 }
````

By checking for the presence of the final bracket, we can either slice to there, or to the end of the content if it is not present.

````
const endIndex = themeContent.lastIndexOf('}');
const rootContent = themeContent.slice(themeContent.indexOf('{') + 1, endIndex === -1 ? undefined : endIndex);
````