### PR TITLE
Avoid missing directory error when running `dev`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /vendor
-/public
+/public/*
+!/public/.gitkeep
 .env
 npm-debug.log


### PR DESCRIPTION
When pulling down a fresh copy of Sage and running `yarn && yarn dev`, the following error occurs due to a missing `public` directory:

```
$ vite
node:fs:2426
    return binding.writeFileUtf8(
                   ^

Error: ENOENT: no such file or directory, open 'public/hot'
    at Object.writeFileSync (node:fs:2426:20)
    at Server.<anonymous> (file:///***/sage/wp-content/themes/sage/node_modules/laravel-vite-plugin/dist/index.js:110:14)
    at Object.onceWrapper (node:events:638:28)
    at Server.emit (node:events:536:35)
    at emitListeningNT (node:net:1980:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:89:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'public/hot'
}
```

This error doesn't occur if you happen to run `yarn build` before `yarn dev`. Adding an empty `public` directory to the repo alleviates this issue. 