### PR TITLE
Remove unused `use` statement in `setup.php`

### DIFF
--- a/app/setup.php
+++ b/app/setup.php
@@ -6,7 +6,6 @@
 
 namespace App;
 
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Vite;
 
 /**


### PR DESCRIPTION
This PR removes an unused import statement (`use Illuminate\Support\Facades\File`) from `app/setup.php`.