### PR TITLE
🔧 Set a default layout content size

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -3,6 +3,9 @@
   "$schema": "https://schemas.wp.org/trunk/theme.json",
   "version": 3,
   "settings": {
+    "layout": {
+      "contentSize": "48rem"
+    },
     "background": {
       "backgroundImage": true
     },


### PR DESCRIPTION
This equates to 768px which is the default width when no `theme.json` exists.