### PR TITLE
🩹 Enable eager loading for images and fonts

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,4 +1,1 @@
-import.meta.glob([
-  '../images/**',
-  '../fonts/**',
-]);
+const assets = import.meta.glob(['../images/**', '../fonts/**'], { eager: true });


### PR DESCRIPTION
Ensure that images and fonts are immediately imported rather than being lazily loaded to ensure that assets are available as URLs when needed

Ref https://discourse.roots.io/t/access-vite-import-meta-glob-image-url-in-js/29448

Will also be updating the https://roots.io/sage/docs/compiling-assets/ docs with an example