### PR TITLE
Always import the editor.css

### DIFF
--- a/app/setup.php
+++ b/app/setup.php
@@ -17,9 +17,7 @@ add_filter('block_editor_settings_all', function ($settings) {
     $style = Vite::asset('resources/css/editor.css');
 
     $settings['styles'][] = [
-        'css' => Vite::isRunningHot()
-            ? "@import url('{$style}')"
-            : Vite::content('resources/css/editor.css'),
+        'css' => "@import url('{$style}')",
     ];
 
     return $settings;


### PR DESCRIPTION
Always import the `editor.css` instead of inlining it when Vite is not running hot.

For example `@font-face` calls require an absolute URL to the font when inlined, due to being called from within an iFrame.
I guess the same issue appears for images referenced within the CSS file.

Instead of putting absolute URL's into the CSS file we can just import the CSS file, that way it uses the hostname of the CSS file.