### PR TITLE
🎨 Simplify the default Composers

### DIFF
--- a/app/View/Composers/App.php
+++ b/app/View/Composers/App.php
@@ -16,23 +16,9 @@ class App extends Composer
     ];
 
     /**
-     * Data to be passed to view before rendering.
-     *
-     * @return array
+     * Retrieve the site name.
      */
-    public function with()
-    {
-        return [
-            'siteName' => $this->siteName(),
-        ];
-    }
-
-    /**
-     * Returns the site name.
-     *
-     * @return string
-     */
-    public function siteName()
+    public function siteName(): string
     {
         return get_bloginfo('name', 'display');
     }

--- a/app/View/Composers/Comments.php
+++ b/app/View/Composers/Comments.php
@@ -16,28 +16,9 @@ class Comments extends Composer
     ];
 
     /**
-     * Data to be passed to view before rendering.
-     *
-     * @return array
-     */
-    public function with()
-    {
-        return [
-            'title' => $this->title(),
-            'responses' => $this->responses(),
-            'previous' => $this->previous(),
-            'next' => $this->next(),
-            'paginated' => $this->paginated(),
-            'closed' => $this->closed(),
-        ];
-    }
-
-    /**
      * The comment title.
-     *
-     * @return string
      */
-    public function title()
+    public function title(): string
     {
         return sprintf(
             /* translators: %1$s is replaced with the number of comments and %2$s with the post title */
@@ -49,13 +30,11 @@ class Comments extends Composer
 
     /**
      * Retrieve the comments.
-     *
-     * @return string
      */
-    public function responses()
+    public function responses(): ?string
     {
         if (! have_comments()) {
-            return;
+            return null;
         }
 
         return wp_list_comments([
@@ -67,13 +46,11 @@ class Comments extends Composer
 
     /**
      * The previous comments link.
-     *
-     * @return string
      */
-    public function previous()
+    public function previous(): ?string
     {
         if (! get_previous_comments_link()) {
-            return;
+            return null;
         }
 
         return get_previous_comments_link(
@@ -83,13 +60,11 @@ class Comments extends Composer
 
     /**
      * The next comments link.
-     *
-     * @return string
      */
-    public function next()
+    public function next(): ?string
     {
         if (! get_next_comments_link()) {
-            return;
+            return null;
         }
 
         return get_next_comments_link(
@@ -99,20 +74,16 @@ class Comments extends Composer
 
     /**
      * Determine if the comments are paginated.
-     *
-     * @return bool
      */
-    public function paginated()
+    public function paginated(): bool
     {
         return get_comment_pages_count() > 1 && get_option('page_comments');
     }
 
     /**
      * Determine if the comments are closed.
-     *
-     * @return bool
      */
-    public function closed()
+    public function closed(): bool
     {
         return ! comments_open() && get_comments_number() != '0' && post_type_supports(get_post_type(), 'comments');
     }

--- a/app/View/Composers/Post.php
+++ b/app/View/Composers/Post.php
@@ -18,24 +18,9 @@ class Post extends Composer
     ];
 
     /**
-     * Data to be passed to view before rendering, but after merging.
-     *
-     * @return array
-     */
-    public function override()
-    {
-        return [
-            'title' => $this->title(),
-            'pagination' => $this->pagination(),
-        ];
-    }
-
-    /**
      * Retrieve the post title.
-     *
-     * @return string
      */
-    public function title()
+    public function title(): string
     {
         if ($this->view->name() !== 'partials.page-header') {
             return get_the_title();
@@ -70,10 +55,8 @@ class Post extends Composer
 
     /**
      * Retrieve the pagination links.
-     *
-     * @return string
      */
-    public function pagination()
+    public function pagination(): string
     {
         return wp_link_pages([
             'echo' => 0,

--- a/resources/views/partials/comments.blade.php
+++ b/resources/views/partials/comments.blade.php
@@ -1,6 +1,6 @@
 @if (! post_password_required())
   <section id="comments" class="comments">
-    @if ($responses)
+    @if ($responses())
       <h2>
         {!! $title !!}
       </h2>
@@ -9,16 +9,16 @@
         {!! $responses !!}
       </ol>
 
-      @if ($paginated)
+      @if ($paginated())
         <nav aria-label="Comment">
           <ul class="pager">
-            @if ($previous)
+            @if ($previous())
               <li class="previous">
                 {!! $previous !!}
               </li>
             @endif
 
-            @if ($next)
+            @if ($next())
               <li class="next">
                 {!! $next !!}
               </li>
@@ -28,7 +28,7 @@
       @endif
     @endif
 
-    @if ($closed)
+    @if ($closed())
       <x-alert type="warning">
         {!! __('Comments are closed.', 'sage') !!}
       </x-alert>

--- a/resources/views/partials/content-page.blade.php
+++ b/resources/views/partials/content-page.blade.php
@@ -1,6 +1,6 @@
 @php(the_content())
 
-@if ($pagination)
+@if ($pagination())
   <nav class="page-nav" aria-label="Page">
     {!! $pagination !!}
   </nav>

--- a/resources/views/partials/content-single.blade.php
+++ b/resources/views/partials/content-single.blade.php
@@ -11,7 +11,7 @@
     @php(the_content())
   </div>
 
-  @if ($pagination)
+  @if ($pagination())
     <footer>
       <nav class="page-nav" aria-label="Page">
         {!! $pagination !!}


### PR DESCRIPTION
When `with()` is not defined, Composers now behave identical to View Components with public methods automatically being available inside configured views.

It's worth noting variables are invokable when not being casted.

```php
// Always true!
@if ($example)
  {{ $example }}
@endif

// Do this instead.
@if ($example())
  {{ $example }}
@endif
```