### PR TITLE
Replace tailwind directives in editor css

### DIFF
--- a/resources/css/editor.css
+++ b/resources/css/editor.css
@@ -1,1 +1,3 @@
-@import "tailwindcss";
+@import "tailwindcss/theme.css";
+@import "tailwindcss/preflight.css";
+@import "tailwindcss/utilities.css";


### PR DESCRIPTION
When the editor is not using an iframe, some WordPress core styles override Tailwind's styles. This occurs because WordPress's built-in styles (e.g., wp-includes/css/dist/block-library/reset.css) are applied directly to the editor content and are unlayered. In contrast, Tailwind styles are applied using CSS layers. Unlayered styles take precedence over layered ones—even if Tailwind's selectors have higher specificity, they can still be overridden by WordPress’s built-in styles.

To ensure Tailwind styles are not layered (and thus have higher precedence), we can import each Tailwind file individually using import directives. This approach prevents Tailwind from being wrapped in a layer, allowing its styles to override the CMS defaults.