### PR TITLE
Acorn application now bootstraps in the after_setup_theme hook

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -19,42 +19,44 @@ if (! file_exists($composer = __DIR__.'/vendor/autoload.php')) {
 
 require $composer;
 
-/*
-|--------------------------------------------------------------------------
-| Register The Bootloader
-|--------------------------------------------------------------------------
-|
-| The first thing we will do is schedule a new Acorn application container
-| to boot when WordPress is finished loading the theme. The application
-| serves as the "glue" for all the components of Laravel and is
-| the IoC container for the system binding all of the various parts.
-|
-*/
+add_action('after_setup_theme', function () {
+    /*
+    |--------------------------------------------------------------------------
+    | Register The Bootloader
+    |--------------------------------------------------------------------------
+    |
+    | The first thing we will do is schedule a new Acorn application container
+    | to boot when WordPress is finished loading the theme. The application
+    | serves as the "glue" for all the components of Laravel and is
+    | the IoC container for the system binding all of the various parts.
+    |
+    */
 
-Application::configure()
-    ->withProviders([
-        App\Providers\ThemeServiceProvider::class,
-    ])
-    ->boot();
+    Application::configure()
+        ->withProviders([
+            App\Providers\ThemeServiceProvider::class,
+        ])
+        ->boot();
 
-/*
-|--------------------------------------------------------------------------
-| Register Sage Theme Files
-|--------------------------------------------------------------------------
-|
-| Out of the box, Sage ships with categorically named theme files
-| containing common functionality and setup to be bootstrapped with your
-| theme. Simply add (or remove) files from the array below to change what
-| is registered alongside Sage.
-|
-*/
+    /*
+    |--------------------------------------------------------------------------
+    | Register Sage Theme Files
+    |--------------------------------------------------------------------------
+    |
+    | Out of the box, Sage ships with categorically named theme files
+    | containing common functionality and setup to be bootstrapped with your
+    | theme. Simply add (or remove) files from the array below to change what
+    | is registered alongside Sage.
+    |
+    */
 
-collect(['setup', 'filters'])
-    ->each(function ($file) {
-        if (! locate_template($file = "app/{$file}.php", true, true)) {
-            wp_die(
-                /* translators: %s is replaced with the relative file path */
-                sprintf(__('Error locating <code>%s</code> for inclusion.', 'sage'), $file)
-            );
-        }
-    });
+    collect(['setup', 'filters'])
+        ->each(function ($file) {
+            if (! locate_template($file = "app/{$file}.php", true, true)) {
+                wp_die(
+                    /* translators: %s is replaced with the relative file path */
+                    sprintf(__('Error locating <code>%s</code> for inclusion.', 'sage'), $file)
+                );
+            }
+        });
+}, 0);


### PR DESCRIPTION
## Why?

I recently tried to add some middleware to my WordPress application, I consulted the [roots.io acorn documentation](https://roots.io/acorn/docs/installation/) though none of the middleware seemed to work.

## What this PR contributes
Aligns bootstrapping of the Acorn application with the Acorn documentation.

- As specified in the [roots.io acorn documentation](https://roots.io/acorn/docs/installation/), the application is now bootstrapped in an `after_setup_theme` hook.
  - This behaviour ensures that adding the `withMiddleware`, `withRouting`,... configuration methods work as expected.

## Caveats
I tested this in a clean Bedrock setup, with a couple plugins enabled. though nothing much. 
I am not sure how breaking this could be for other parts of sage? In my mind this hook could be troublesome when there is an attempt to interact with the bootstrapped application before this hook ran.
***
I opted to create a PR over discussing this on the forums first, I hope that is ok (Should it not be, please let me know and I will take this into account towards future trains of thought)