### PR TITLE
⬆️ Bump dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
     "config:recommended",
     "schedule:weekly"
   ],
-  "rangeStrategy": "bump",
+  "rangeStrategy": "replace",
   "ignoreDeps": ["php"],
   "packageRules": [
     {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "translate:mo": "wp i18n make-mo ./resources/lang ./resources/lang"
   },
   "devDependencies": {
-    "@roots/vite-plugin": "^1.0.2",
-    "@tailwindcss/vite": "^4.0.9",
-    "laravel-vite-plugin": "^1.2.0",
-    "tailwindcss": "^4.0.9",
-    "vite": "^6.2.0"
+    "@roots/vite-plugin": "^1.0.0",
+    "@tailwindcss/vite": "^4.0.0",
+    "laravel-vite-plugin": "^2.0.0",
+    "tailwindcss": "^4.0.0",
+    "vite": "^7.0.0"
   }
 }


### PR DESCRIPTION
* Bumped npm dependencies to latest versions
* Relaxed version constraints in `package.json`
* Changed Renovate config from "bump" to "replace" strategy to reduce unnecessary PRs when latest versions are already installable within current ranges