### PR TITLE
🔧 Set APP_URL for Laravel Vite plugin

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,9 @@ import tailwindcss from '@tailwindcss/vite';
 import laravel from 'laravel-vite-plugin'
 import { wordpressPlugin, wordpressThemeJson } from '@roots/vite-plugin';
 
+// Set APP_URL for Laravel Vite plugin
+process.env.APP_URL = 'http://example.test';
+
 export default defineConfig({
   base: '/app/themes/sage/public/build/',
   plugins: [


### PR DESCRIPTION
This prevents the "APP_URL: undefined" message when running the Vite dev server

* [ ] Update docs