### PR TITLE
🔧 Fix filter to action for admin head in setup

### DIFF
--- a/app/setup.php
+++ b/app/setup.php
@@ -28,7 +28,7 @@ add_filter('block_editor_settings_all', function ($settings) {
  *
  * @return void
  */
-add_filter('admin_head', function () {
+add_action('admin_head', function () {
     if (! get_current_screen()?->is_block_editor()) {
         return;
     }


### PR DESCRIPTION
I understand that [admin_head](https://developer.wordpress.org/reference/hooks/admin_head/) only exists as an `action`, not as a `filter`, or am I wrong?