### PR TITLE
🐛 Fix block-style-variation-styles dependency error on WP 6.9.1

### DIFF
--- a/app/setup.php
+++ b/app/setup.php
@@ -58,6 +58,13 @@ add_filter('theme_file_path', function ($path, $file) {
 }, 10, 2);
 
 /**
+ * Disable on-demand block asset loading.
+ *
+ * @link https://core.trac.wordpress.org/ticket/61965
+ */
+add_filter('should_load_separate_core_block_assets', '__return_false');
+
+/**
  * Register the initial theme setup.
  *
  * @return void


### PR DESCRIPTION
## Summary

- Disable on-demand block asset loading to fix the `block-style-variation-styles` unregistered `global-styles` dependency error introduced in WP 6.9.1
- Classic themes like Sage are affected because `global-styles` isn't always registered early enough when on-demand loading is enabled
- See https://core.trac.wordpress.org/ticket/61965

Close #3278

🤖 Generated with [Claude Code](https://claude.com/claude-code)