### PR TITLE
Support quotation marks in query field

### DIFF
--- a/resources/views/forms/search.blade.php
+++ b/resources/views/forms/search.blade.php
@@ -7,7 +7,7 @@
     <input
       type="search"
       placeholder="{!! esc_attr_x('Search &hellip;', 'placeholder', 'sage') !!}"
-      value="{{ get_search_query() }}"
+      value="{!! get_search_query() !!}"
       name="s"
     >
   </label>


### PR DESCRIPTION
When using quotation marks in the query field, which is supported by Wordpress, the query is transformed to
`&quot;multiple words&quot;`
on the next page load. Easily fixed this way.